### PR TITLE
[Refactor] 에러 응답 처리 리팩토링

### DIFF
--- a/module-common/src/main/java/com/back2basics/response/global/error/ErrorResponse.java
+++ b/module-common/src/main/java/com/back2basics/response/global/error/ErrorResponse.java
@@ -1,6 +1,7 @@
 package com.back2basics.response.global.error;
 
 import com.back2basics.response.global.code.CommonErrorCode;
+import com.back2basics.response.global.code.ErrorCode;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.ConstraintViolation;
 import java.util.ArrayList;
@@ -18,64 +19,99 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	private List<FieldError> errors;
+    private ErrorCode errorCode;
 
-	public ErrorResponse(List<FieldError> errors) {
-		this.errors = errors;
-	}
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<FieldError> errors;
 
-	// todo errorCode field 수정
-	public static ErrorResponse of() {
-		return new ErrorResponse(Collections.emptyList());
-	}
+    public ErrorResponse(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.errors = Collections.emptyList();
+    }
 
-	public static ErrorResponse of(BindingResult bindingResult) {
-		return new ErrorResponse(FieldError.of(bindingResult));
-	}
+    public ErrorResponse(ErrorCode errorCode, List<FieldError> errors) {
+        this.errors = errors;
+        this.errorCode = errorCode;
+    }
 
-	public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
-		String value = e.getValue() == null ? "" : e.getValue().toString();
-		return new ErrorResponse(
-			FieldError.of(e.getName(), value, CommonErrorCode.INVALID_TYPE_VALUE.getMessage()));
-	}
+    // @Valid + @RequestBody에서 나오는 에러
+    public static ErrorResponse of(final ErrorCode errorCode, final BindingResult bindingResult) {
+        return new ErrorResponse(errorCode, FieldError.of(bindingResult));
+    }
 
-	@Getter
-	@NoArgsConstructor(access = AccessLevel.PROTECTED)
-	public static class FieldError {
+    // @Validated + @RequestParam, @PathVariable 에서 나오는 에러
+    public static ErrorResponse of(final ErrorCode errorCode,
+        final Set<ConstraintViolation<?>> violations) {
+        return new ErrorResponse(errorCode, FieldError.of(violations));
+    }
 
-		private String field;
-		private String value;
-		private String reason;
+    // No-Parameter
+    public static ErrorResponse of(final ErrorCode errorCode,
+        final String missingParameterName) {
+        return new ErrorResponse(errorCode,
+            FieldError.of(missingParameterName, "", errorCode.getMessage()));
+    }
 
-		public FieldError(String field, String value, String reason) {
-			this.field = field;
-			this.value = value;
-			this.reason = reason;
-		}
+    // 에러코드만 전달(주로 커스텀익셉션)
+    public static ErrorResponse of(final ErrorCode errorCode) {
+        return new ErrorResponse(errorCode);
+    }
 
-		public static List<FieldError> of(String field, String value, String reason) {
-			List<FieldError> list = new ArrayList<>();
-			list.add(new FieldError(field, value, reason));
-			return list;
-		}
+    // 단일 필드 에러
+    public static ErrorResponse of(final ErrorCode errorCode,
+        final String field, final String value, final String reason) {
+        return new ErrorResponse(errorCode, FieldError.of(field, value, reason));
+    }
 
-		public static List<FieldError> of(BindingResult bindingResult) {
-			return bindingResult.getFieldErrors().stream()
-				.map(error -> new FieldError(
-					error.getField(),
-					error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
-					error.getDefaultMessage()))
-				.collect(Collectors.toList());
-		}
+    // 에러코드 + 필드 목록
+    public static ErrorResponse of(final ErrorCode errorCode, final List<FieldError> fieldErrors) {
+        return new ErrorResponse(errorCode, fieldErrors);
+    }
 
-		public static List<FieldError> of(Set<ConstraintViolation<?>> violations) {
-			return violations.stream()
-				.map(v -> new FieldError(
-					v.getPropertyPath().toString(),
-					"",
-					v.getMessage()))
-				.collect(Collectors.toList());
-		}
-	}
+    // 잘못된 HTTP 메소드 타입
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        String value = e.getValue() == null ? "" : e.getValue().toString();
+        return new ErrorResponse(CommonErrorCode.INVALID_TYPE_VALUE,
+            FieldError.of(e.getName(), value, CommonErrorCode.INVALID_TYPE_VALUE.getMessage()));
+    }
+
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+
+        private String field;
+        private String value;
+        private String reason;
+
+        public FieldError(String field, String value, String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        public static List<FieldError> of(String field, String value, String reason) {
+            List<FieldError> list = new ArrayList<>();
+            list.add(new FieldError(field, value, reason));
+            return list;
+        }
+
+        public static List<FieldError> of(BindingResult bindingResult) {
+            return bindingResult.getFieldErrors().stream()
+                .map(error -> new FieldError(
+                    error.getField(),
+                    error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                    error.getDefaultMessage()))
+                .collect(Collectors.toList());
+        }
+
+        public static List<FieldError> of(Set<ConstraintViolation<?>> violations) {
+            return violations.stream()
+                .map(v -> new FieldError(
+                    v.getPropertyPath().toString(),
+                    "",
+                    v.getMessage()))
+                .collect(Collectors.toList());
+        }
+    }
 }

--- a/module-common/src/main/java/com/back2basics/response/global/error/ErrorResponse.java
+++ b/module-common/src/main/java/com/back2basics/response/global/error/ErrorResponse.java
@@ -2,6 +2,7 @@ package com.back2basics.response.global.error;
 
 import com.back2basics.response.global.code.CommonErrorCode;
 import com.back2basics.response.global.code.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.ConstraintViolation;
 import java.util.ArrayList;
@@ -19,6 +20,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
 
+    @JsonIgnore // 응답에서 제외
     private ErrorCode errorCode;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -30,8 +32,8 @@ public class ErrorResponse {
     }
 
     public ErrorResponse(ErrorCode errorCode, List<FieldError> errors) {
-        this.errors = errors;
         this.errorCode = errorCode;
+        this.errors = errors;
     }
 
     // @Valid + @RequestBody에서 나오는 에러
@@ -55,12 +57,6 @@ public class ErrorResponse {
     // 에러코드만 전달(주로 커스텀익셉션)
     public static ErrorResponse of(final ErrorCode errorCode) {
         return new ErrorResponse(errorCode);
-    }
-
-    // 단일 필드 에러
-    public static ErrorResponse of(final ErrorCode errorCode,
-        final String field, final String value, final String reason) {
-        return new ErrorResponse(errorCode, FieldError.of(field, value, reason));
     }
 
     // 에러코드 + 필드 목록

--- a/module-common/src/main/java/com/back2basics/response/global/result/ApiResponse.java
+++ b/module-common/src/main/java/com/back2basics/response/global/result/ApiResponse.java
@@ -3,6 +3,7 @@ package com.back2basics.response.global.result;
 import com.back2basics.response.global.code.BaseCode;
 import com.back2basics.response.global.code.ErrorCode;
 import com.back2basics.response.global.code.ResponseCode;
+import com.back2basics.response.global.error.ErrorResponse;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -11,47 +12,47 @@ import org.springframework.http.ResponseEntity;
 @Getter
 public class ApiResponse<T> {
 
-	private final HttpStatus status;
-	private final String code;
-	private final String message;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	private final T data;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final T data;
 
-	public ApiResponse(BaseCode baseCode, T data) {
-		this.status = baseCode.getStatus();
-		this.code = baseCode.getCode();
-		this.message = baseCode.getMessage();
-		this.data = data;
-	}
+    public ApiResponse(BaseCode baseCode, T data) {
+        this.status = baseCode.getStatus();
+        this.code = baseCode.getCode();
+        this.message = baseCode.getMessage();
+        this.data = data;
+    }
 
-	public ApiResponse(BaseCode baseCode) {
-		this(baseCode, null);
-	}
+    public ApiResponse(BaseCode baseCode) {
+        this(baseCode, null);
+    }
 
-	public static <T> ResponseEntity<ApiResponse<T>> success(
-		ResponseCode responseCode, T data) {
-		return ResponseEntity
-			.status(responseCode.getStatus())
-			.body(new ApiResponse<>(responseCode, data));
-	}
+    public static <T> ResponseEntity<ApiResponse<T>> success(
+        ResponseCode responseCode, T data) {
+        return ResponseEntity
+            .status(responseCode.getStatus())
+            .body(new ApiResponse<>(responseCode, data));
+    }
 
-	public static ResponseEntity<ApiResponse<Void>> success(
-		ResponseCode responseCode) {
-		return ResponseEntity
-			.status(responseCode.getStatus())
-			.body(new ApiResponse<>(responseCode));
-	}
+    public static ResponseEntity<ApiResponse<Void>> success(
+        ResponseCode responseCode) {
+        return ResponseEntity
+            .status(responseCode.getStatus())
+            .body(new ApiResponse<>(responseCode));
+    }
 
-	public static ResponseEntity<ApiResponse<Void>> error(ErrorCode errorCode) {
-		return ResponseEntity
-			.status(errorCode.getStatus())
-			.body(new ApiResponse<>(errorCode));
-	}
+    public static ResponseEntity<ApiResponse<ErrorResponse>> error(ErrorCode errorCode) {
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(new ApiResponse<>(errorCode));
+    }
 
-	public static <T> ResponseEntity<ApiResponse<T>> error(ErrorCode code, T errorDetails) {
-		return ResponseEntity
-			.status(code.getStatus())
-			.body(new ApiResponse<>(code, errorDetails));
-	}
+    public static <T> ResponseEntity<ApiResponse<T>> error(ErrorCode errorCode, T errorDetails) {
+        return ResponseEntity
+            .status(errorCode.getStatus())
+            .body(new ApiResponse<>(errorCode, errorDetails));
+    }
 }

--- a/module-web/src/main/java/com/back2basics/global/handler/GlobalExceptionHandler.java
+++ b/module-web/src/main/java/com/back2basics/global/handler/GlobalExceptionHandler.java
@@ -3,14 +3,16 @@ package com.back2basics.global.handler;
 import com.back2basics.response.global.code.CommonErrorCode;
 import com.back2basics.response.global.code.ErrorCode;
 import com.back2basics.response.global.error.CustomException;
-import com.back2basics.response.global.error.ErrorResponse.FieldError;
+import com.back2basics.response.global.error.ErrorResponse;
 import com.back2basics.response.global.result.ApiResponse;
-import java.util.List;
+import jakarta.validation.ConstraintViolationException;
 import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -19,53 +21,98 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-	@ExceptionHandler(NoSuchElementException.class)
-	protected ResponseEntity<ApiResponse<Void>> handleNoSuchElementException(
-		NoSuchElementException ex) {
-		ErrorCode errorCode = CommonErrorCode.NOT_FOUND;
-		log.error("NoSuchElementException 발생: {}", errorCode.getMessage());
-		return ApiResponse.error(errorCode);
-	}
+    // 찾는거 없는 경우(Optional.orElseThrow 같은거)
+    @ExceptionHandler(NoSuchElementException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleNoSuchElementException(
+        NoSuchElementException ex) {
+        ErrorCode errorCode = CommonErrorCode.NOT_FOUND;
+        log.error("NoSuchElementException 발생 {}: {}", ex.getClass().getSimpleName(),
+            ex.getMessage(), ex);
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        return ApiResponse.error(errorCode, errorResponse);
+    }
 
-	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
-	protected ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
-		MethodArgumentTypeMismatchException ex) {
-		ErrorCode errorCode = CommonErrorCode.BAD_REQUEST;
-		log.error("MethodArgumentTypeMismatchException 발생: {}", errorCode.getMessage());
-		return ApiResponse.error(errorCode);
-	}
+    // @RequestParam 등에서 타입이 맞지 않을 경우
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodArgumentTypeMismatchException(
+        MethodArgumentTypeMismatchException ex) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_TYPE_VALUE;
+        log.error("MethodArgumentTypeMismatchException 발생 {}: {}", ex.getClass().getSimpleName(),
+            ex.getMessage(), ex);
+        ErrorResponse errorResponse = ErrorResponse.of(ex);
+        return ApiResponse.error(errorCode, errorResponse);
+    }
 
-	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-	protected ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupportedException(
-		HttpRequestMethodNotSupportedException e) {
-		ErrorCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
-		log.error("HttpRequestMethodNotSupportedException 발생: {}", errorCode.getMessage());
-		return ApiResponse.error(errorCode);
-	}
+    // HTTP 메소드 타입 잘못 줬을 때
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleHttpRequestMethodNotSupportedException(
+        HttpRequestMethodNotSupportedException ex) {
+        ErrorCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
+        log.error("HttpRequestMethodNotSupportedException 발생 {}: {}", ex.getClass().getSimpleName(),
+            ex.getMessage(), ex);
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        return ApiResponse.error(errorCode, errorResponse);
+    }
 
-	// @Valid, @Validated 에서 binding error 발생 시 (@RequestBody)
-	@ExceptionHandler(MethodArgumentNotValidException.class)
-	protected ResponseEntity<ApiResponse<List<FieldError>>> handleMethodArgumentNotValidException(
-		MethodArgumentNotValidException e) {
-		ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
-		List<FieldError> fieldErrors = FieldError.of(e.getBindingResult());
-		log.error("MethodArgumentNotValidException 발생: {}", errorCode.getMessage());
-		return ApiResponse.error(errorCode, fieldErrors);
-	}
+    // 요청 파라미터가 누락됐을 때
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMissingServletRequestParameterException(
+        MissingServletRequestParameterException ex) {
+        ErrorCode errorCode = CommonErrorCode.METHOD_NOT_ALLOWED;
+        log.error("HttpRequestMethodNotSupportedException 발생 {}: {}", ex.getClass().getSimpleName(),
+            ex.getMessage(), ex);
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        return ApiResponse.error(errorCode, errorResponse);
+    }
 
-	// 비즈니스 요구사항에 따라 커스텀해준 익셉션들
-	@ExceptionHandler(CustomException.class)
-	public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {
-		ErrorCode errorCode = e.getErrorCode();
-		log.error("CustomException 발생: {}", e.getErrorCode().getMessage());
-		return ApiResponse.error(errorCode);
-	}
+    // 폼 데이터 바인딩할 때 유효성 검사 실패하면 여기서 잡아줌
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleBindException(BindException ex) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
+        log.error("BindException 발생 {}: {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode, ex.getBindingResult());
+        return ApiResponse.error(errorCode, errorResponse);
+    }
 
-	// 그 밖에 발생하는 모든 예외처리는 여기서 잡음
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-		log.error("서버 에러 발생 {}", e.getMessage());
-		ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
-		return ApiResponse.error(errorCode);
-	}
+    // @Validated 먹여준 @RequestParam이나 @PathVariable 같은 데서 유효성 검사 실패하면 여기서 처리함
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleConstraintViolationException(
+        ConstraintViolationException ex) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
+        log.error("ConstraintViolationException 발생 {}: {}", ex.getClass().getSimpleName(),
+            ex.getMessage(), ex);
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode, ex.getConstraintViolations());
+        return ApiResponse.error(errorCode, errorResponse);
+    }
+
+    // @Valid + @RequestBody, @Validated 에서 binding error 발생 시(@Valid command)
+    // JSON 바디 같은 거 @Valid 붙여서 검사하다가 실패하면 여기서 처리하는 거임
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException ex) {
+        ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
+        log.error("MethodArgumentNotValidException 발생: {}", errorCode.getMessage());
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode, ex.getBindingResult());
+        return ApiResponse.error(errorCode, errorResponse);
+    }
+
+    // 비즈니스 요구사항에 따라 커스텀해준 익셉션들
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        log.error("CustomException 발생 {}: {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
+        return ex.getErrors().isEmpty()
+            ? ApiResponse.error(errorCode, ErrorResponse.of(errorCode))
+            : ApiResponse.error(errorCode, ErrorResponse.of(errorCode, ex.getErrors()));
+    }
+
+    // 그 밖에 발생하는 모든 예외처리는 여기서 잡음
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<ErrorResponse>> handleException(Exception ex) {
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        log.error("UnhandledException 발생 {}: {}", ex.getClass().getSimpleName(), ex.getMessage(),
+            ex);
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        return ApiResponse.error(errorCode, errorResponse);
+    }
 }

--- a/module-web/src/main/java/com/back2basics/global/handler/GlobalExceptionHandler.java
+++ b/module-web/src/main/java/com/back2basics/global/handler/GlobalExceptionHandler.java
@@ -86,7 +86,7 @@ public class GlobalExceptionHandler {
     }
 
     // @Valid + @RequestBody, @Validated 에서 binding error 발생 시(@Valid command)
-    // JSON 바디 같은 거 @Valid 붙여서 검사하다가 실패하면 여기서 처리하는 거임
+    // json 바디 같은 거 @Valid 붙여서 검사하다가 실패하면 여기서 처리하는 거임
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodArgumentNotValidException(
         MethodArgumentNotValidException ex) {


### PR DESCRIPTION
## 📌 개요
<!-- 어떤 변경을 했는지 한두 문장으로 설명해주세요 -->
<!-- ex) 회원가입 API 및 검증 로직 추가 -->

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 의도한 객체로 응답되지 않는 현상 수정
- 의도가 애매하게 작성된 of메소드 수정
- 파라미터 및 메소드명 모두 통일
- ErrorResponse 클래스의 of메소드 쓰임에 따라 수정/삭제/추가
- GlobalExceptionHandler에서 통일되지 않는 리턴타입, 파라미터 전달, of메소드 호출 등 리팩토링 및 주석 설명 추가
- 모든 에러 응답이 같은 형식의 json으로 응답될 수 있도록 형식 통일
- 개발 과정에서 흔하게 발생할 수 있는 익셉션들 추가로 Handler에 추가, 이에 따른 의존 클래스들 수정
- 에러 로그를 더 상세히 출력하도록 수정
- 쓰이지 않는 코드 모두 삭제
- data 필드가 null 혹은 empty일 경우 리턴되지 않도록 로직 추가
- json 응답에서 중복으로 출력되는 필드값 수정

## 🔍 관련 이슈
<!-- 예: Close #12 -->
- Close #33 
- See also #32 

## 🧪 테스트 결과
<img width="885" alt="image" src="https://github.com/user-attachments/assets/5a4f067d-ab5b-4bf8-98d0-9b9e1ce71a98" />

## 👀 리뷰어에게 요청사항
- BaseCoe로 수정 후 `int code`가 아닌 `HttpStatus code` 로 수정하였기 때문에 http상태값(200, 404, ...)은 응답 객체에서 찾아볼 수 없는데, 나중에 프론트엔드 작업할 때 필요하게 될 가능성도 있어보입니다. 
   -> 간단하게 수정 가능하니 문제 시 바로 이슈올려주세요.
- 이미지에 status랑 message 다르게 나오는 것은 크게 상관 없습니다.(status가 좀 더 범용적인 에러처리로 처리되고있음)
- status는 `org.springframework.http`의 `HttpStatus` 값을 사용한 필드인 것이 원인입니다.


## 📎 기타 참고 사항
이슈 #33  의 코멘트에서 언급한대로
일부 코드만 수정했음에도 불구하고 포맷터 자동 적용으로 인해 전체 파일 수정 처리가 된 것 같습니다.
이 점 참고하시고 앞으로 코드 작성자에게 직접 수정 요청하는 방식이 좋아보입니다.
> 자신의 작업 내용이 다른 사람 이름으로 커밋이 덮어써집니다. 딱히 상관 없으시면 상관 없습니다 🫤
