### PR TITLE
[Refactor] dto 및 기타 유틸 파일 위치,이름 수정

### DIFF
--- a/module-application/src/test/java/com/back2basics/comment/service/CommentServiceImplTest.java
+++ b/module-application/src/test/java/com/back2basics/comment/service/CommentServiceImplTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.back2basics.infra.comment.validation.CommentValidator;
+import com.back2basics.infra.validation.CommentValidator;
 import com.back2basics.model.comment.Comment;
 import com.back2basics.model.post.Post;
 import com.back2basics.model.post.PostStatus;

--- a/module-application/src/test/java/com/back2basics/comment/validator/CommentValidatorTest.java
+++ b/module-application/src/test/java/com/back2basics/comment/validator/CommentValidatorTest.java
@@ -3,7 +3,7 @@ package com.back2basics.comment.validator;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-import com.back2basics.infra.comment.validation.CommentValidator;
+import com.back2basics.infra.validation.CommentValidator;
 import com.back2basics.model.comment.Comment;
 import com.back2basics.port.out.comment.CommentRepositoryPort;
 import com.back2basics.service.comment.exception.CommentErrorCode;

--- a/module-application/src/test/java/com/back2basics/post/service/PostServiceImplTest.java
+++ b/module-application/src/test/java/com/back2basics/post/service/PostServiceImplTest.java
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.back2basics.infra.post.validation.PostValidator;
+import com.back2basics.infra.validation.PostValidator;
 import com.back2basics.model.post.Post;
 import com.back2basics.model.post.PostStatus;
 import com.back2basics.port.out.post.PostRepositoryPort;

--- a/module-application/src/test/java/com/back2basics/post/validator/PostValidatorTest.java
+++ b/module-application/src/test/java/com/back2basics/post/validator/PostValidatorTest.java
@@ -3,7 +3,7 @@ package com.back2basics.post.validator;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-import com.back2basics.infra.post.validation.PostValidator;
+import com.back2basics.infra.validation.PostValidator;
 import com.back2basics.model.post.Post;
 import com.back2basics.model.post.PostStatus;
 import com.back2basics.port.out.post.PostRepositoryPort;

--- a/module-core/src/main/java/com/back2basics/infra/custom/CustomEnumCheck.java
+++ b/module-core/src/main/java/com/back2basics/infra/custom/CustomEnumCheck.java
@@ -1,4 +1,4 @@
-package com.back2basics.infra.post.custom;
+package com.back2basics.infra.custom;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
@@ -9,14 +9,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Documented
-@Constraint(validatedBy = CustomNotBlankValidator.class)
+@Constraint(validatedBy = CustomEnumCheckValidator.class)
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CustomNotBlank {
+public @interface CustomEnumCheck {
 
-    String message();
+    String message() default "유효하지 않은 값입니다.";
 
     Class<?>[] groups() default {};
 
     Class<? extends Payload>[] payload() default {};
+
+    Class<? extends Enum<?>> enumClass(); // 체크할 enum type
 }

--- a/module-core/src/main/java/com/back2basics/infra/custom/CustomEnumCheckValidator.java
+++ b/module-core/src/main/java/com/back2basics/infra/custom/CustomEnumCheckValidator.java
@@ -1,4 +1,4 @@
-package com.back2basics.infra.post.custom;
+package com.back2basics.infra.custom;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/module-core/src/main/java/com/back2basics/infra/custom/CustomNotBlank.java
+++ b/module-core/src/main/java/com/back2basics/infra/custom/CustomNotBlank.java
@@ -1,4 +1,4 @@
-package com.back2basics.infra.post.custom;
+package com.back2basics.infra.custom;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
@@ -9,16 +9,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Documented
-@Constraint(validatedBy = CustomEnumCheckValidator.class)
+@Constraint(validatedBy = CustomNotBlankValidator.class)
 @Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CustomEnumCheck {
+public @interface CustomNotBlank {
 
-    String message() default "유효하지 않은 값입니다.";
+    String message();
 
     Class<?>[] groups() default {};
 
     Class<? extends Payload>[] payload() default {};
-
-    Class<? extends Enum<?>> enumClass(); // 체크할 enum type
 }

--- a/module-core/src/main/java/com/back2basics/infra/custom/CustomNotBlankValidator.java
+++ b/module-core/src/main/java/com/back2basics/infra/custom/CustomNotBlankValidator.java
@@ -1,4 +1,4 @@
-package com.back2basics.infra.post.custom;
+package com.back2basics.infra.custom;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/module-core/src/main/java/com/back2basics/infra/validation/CommentValidator.java
+++ b/module-core/src/main/java/com/back2basics/infra/validation/CommentValidator.java
@@ -1,4 +1,4 @@
-package com.back2basics.infra.comment.validation;
+package com.back2basics.infra.validation;
 
 import com.back2basics.model.comment.Comment;
 import com.back2basics.port.out.comment.CommentRepositoryPort;

--- a/module-core/src/main/java/com/back2basics/infra/validation/PostValidator.java
+++ b/module-core/src/main/java/com/back2basics/infra/validation/PostValidator.java
@@ -1,4 +1,4 @@
-package com.back2basics.infra.post.validation;
+package com.back2basics.infra.validation;
 
 import com.back2basics.model.post.Post;
 import com.back2basics.port.out.post.PostRepositoryPort;

--- a/module-core/src/main/java/com/back2basics/service/comment/CommentModelRelationHelper.java
+++ b/module-core/src/main/java/com/back2basics/service/comment/CommentModelRelationHelper.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class CommentRelationService {
+public class CommentModelRelationHelper {
 
     private final PostValidator postValidator;
     private final CommentValidator commentValidator;

--- a/module-core/src/main/java/com/back2basics/service/comment/CommentModelRelationHelper.java
+++ b/module-core/src/main/java/com/back2basics/service/comment/CommentModelRelationHelper.java
@@ -1,7 +1,7 @@
 package com.back2basics.service.comment;
 
-import com.back2basics.infra.comment.validation.CommentValidator;
-import com.back2basics.infra.post.validation.PostValidator;
+import com.back2basics.infra.validation.CommentValidator;
+import com.back2basics.infra.validation.PostValidator;
 import com.back2basics.model.comment.Comment;
 import com.back2basics.model.post.Post;
 import com.back2basics.service.comment.dto.CommentCreateCommand;

--- a/module-core/src/main/java/com/back2basics/service/comment/CommentServiceImpl.java
+++ b/module-core/src/main/java/com/back2basics/service/comment/CommentServiceImpl.java
@@ -20,7 +20,7 @@ public class CommentServiceImpl implements
 
     private final CommentRepositoryPort commentRepositoryPort;
     private final CommentValidator commentValidator;
-    private final CommentRelationService commentRelationService;
+    private final CommentModelRelationHelper commentModelRelationHelper;
 
 
     @Override
@@ -32,7 +32,7 @@ public class CommentServiceImpl implements
             .parentCommentId(command.getParentId())
             .build();
 
-        commentRelationService.assignRelations(command, comment);
+        commentModelRelationHelper.assignRelations(command, comment);
 
         return commentRepositoryPort.save(comment);
     }

--- a/module-core/src/main/java/com/back2basics/service/comment/CommentServiceImpl.java
+++ b/module-core/src/main/java/com/back2basics/service/comment/CommentServiceImpl.java
@@ -1,6 +1,6 @@
 package com.back2basics.service.comment;
 
-import com.back2basics.infra.comment.validation.CommentValidator;
+import com.back2basics.infra.validation.CommentValidator;
 import com.back2basics.model.comment.Comment;
 import com.back2basics.port.in.comment.CreateCommentUseCase;
 import com.back2basics.port.in.comment.DeleteCommentUseCase;

--- a/module-core/src/main/java/com/back2basics/service/comment/dto/CommentUpdateCommand.java
+++ b/module-core/src/main/java/com/back2basics/service/comment/dto/CommentUpdateCommand.java
@@ -1,6 +1,6 @@
 package com.back2basics.service.comment.dto;
 
-import com.back2basics.infra.post.custom.CustomNotBlank;
+import com.back2basics.infra.custom.CustomNotBlank;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/module-core/src/main/java/com/back2basics/service/post/PostServiceImpl.java
+++ b/module-core/src/main/java/com/back2basics/service/post/PostServiceImpl.java
@@ -1,6 +1,6 @@
 package com.back2basics.service.post;
 
-import com.back2basics.infra.post.validation.PostValidator;
+import com.back2basics.infra.validation.PostValidator;
 import com.back2basics.model.post.Post;
 import com.back2basics.model.post.PostStatus;
 import com.back2basics.port.in.post.CreatePostUseCase;

--- a/module-core/src/main/java/com/back2basics/service/post/dto/PostCreateCommand.java
+++ b/module-core/src/main/java/com/back2basics/service/post/dto/PostCreateCommand.java
@@ -1,6 +1,6 @@
 package com.back2basics.service.post.dto;
 
-import com.back2basics.infra.post.custom.CustomEnumCheck;
+import com.back2basics.infra.custom.CustomEnumCheck;
 import com.back2basics.model.post.PostType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/module-core/src/main/java/com/back2basics/service/post/dto/PostUpdateCommand.java
+++ b/module-core/src/main/java/com/back2basics/service/post/dto/PostUpdateCommand.java
@@ -1,7 +1,7 @@
 package com.back2basics.service.post.dto;
 
-import com.back2basics.infra.post.custom.CustomEnumCheck;
-import com.back2basics.infra.post.custom.CustomNotBlank;
+import com.back2basics.infra.custom.CustomEnumCheck;
+import com.back2basics.infra.custom.CustomNotBlank;
 import com.back2basics.model.post.PostStatus;
 import com.back2basics.model.post.PostType;
 import jakarta.validation.constraints.Size;

--- a/module-jpa/src/main/java/com/back2basics/comment/utils/CommentDeleteHelper.java
+++ b/module-jpa/src/main/java/com/back2basics/comment/utils/CommentDeleteHelper.java
@@ -1,0 +1,27 @@
+package com.back2basics.comment.utils;
+
+import com.back2basics.comment.entity.CommentEntity;
+import com.back2basics.comment.repository.CommentEntityRepository;
+import com.back2basics.service.comment.exception.CommentErrorCode;
+import com.back2basics.service.comment.exception.CommentException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CommentDeleteHelper {
+
+    private final CommentEntityRepository commentRepository;
+
+    @Transactional
+    public void deleteCommentWithOrphanKeep(Long commentId) {
+        CommentEntity parent = commentRepository.findById(commentId)
+            .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        parent.getChildrenComments().forEach(child -> child.assignParentComment(null));
+        parent.getChildrenComments().clear();
+
+        commentRepository.delete(parent);
+    }
+}

--- a/module-jpa/src/main/java/com/back2basics/comment/utils/CommentRelationHelper.java
+++ b/module-jpa/src/main/java/com/back2basics/comment/utils/CommentRelationHelper.java
@@ -1,4 +1,4 @@
-package com.back2basics.comment.adapter.out;
+package com.back2basics.comment.utils;
 
 import com.back2basics.comment.entity.CommentEntity;
 import com.back2basics.comment.repository.CommentEntityRepository;
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class CommentRelationAdapter {
+public class CommentRelationHelper {
 
     private final PostEntityRepository postEntityRepository;
     private final CommentEntityRepository commentRepository;

--- a/module-jpa/src/main/java/com/back2basics/comment/utils/CommentUpdateHelper.java
+++ b/module-jpa/src/main/java/com/back2basics/comment/utils/CommentUpdateHelper.java
@@ -1,7 +1,8 @@
-package com.back2basics.comment.adapter.out;
+package com.back2basics.comment.utils;
 
 import com.back2basics.comment.entity.CommentEntity;
 import com.back2basics.comment.repository.CommentEntityRepository;
+import com.back2basics.model.comment.Comment;
 import com.back2basics.service.comment.exception.CommentErrorCode;
 import com.back2basics.service.comment.exception.CommentException;
 import lombok.RequiredArgsConstructor;
@@ -10,18 +11,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-public class CommentDeleteHelper {
+public class CommentUpdateHelper {
 
     private final CommentEntityRepository commentRepository;
 
     @Transactional
-    public void deleteCommentWithOrphanKeep(Long commentId) {
-        CommentEntity parent = commentRepository.findById(commentId)
+    public CommentEntity updateComment(Long commentId, Comment comment) {
+        CommentEntity entity = commentRepository.findById(commentId)
             .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
 
-        parent.getChildrenComments().forEach(child -> child.assignParentComment(null));
-        parent.getChildrenComments().clear();
-
-        commentRepository.delete(parent);
+        entity.updateContent(comment.getContent());
+        return entity;
     }
 }


### PR DESCRIPTION
## 📌 개요
-core/infra/custom 에 작성된 커스텀 어노테이션 클래스들의 위치를 더 상위로 수정합니다.
- adapter에 무분별하게 생성된 util 클래스들의 이름을 변경하고 /util 하위로 수정합니다.

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- `/infra/domain` -> `/infra/custom/domain`, `/infra/validation/domain` 로 위치 수정하였습니다.
- `CommentJpaAdapter` 에서 사용하는 utils 클래스들의 이름을 `Helper` 로 통일하였습니다.
     - 연관관계 설정에 의한 코드를 jpaAdapter 클래스 내부에 써주는 대신 담당 클래스를 두어 역할을 분리하였습니다.
- `CommentJpaAdaper` 에서 updateHelper를 추가하여 중복 코드를 개선하였습니다.

## 🔍 관련 이슈
- Close #43 

## 🧪 테스트 결과

## 👀 리뷰어에게 요청사항
- 수정된 디렉토리 구조 및 클래스 이름 등이 적절한지 체크해주세요

## 📎 기타 참고 사항


