### PR TITLE
[Feature] 삭제되지않은 프로젝트 조회 및 상태 변경 추가(#48)

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/project/controller/ProjectController.java
+++ b/module-api/src/main/java/com/back2basics/domain/project/controller/ProjectController.java
@@ -1,5 +1,9 @@
 package com.back2basics.domain.project.controller;
 
+import com.back2basics.domain.project.dto.request.ProjectCreateRequest;
+import com.back2basics.domain.project.dto.request.ProjectUpdateRequest;
+import com.back2basics.domain.project.dto.response.ProjectGetResponse;
+import com.back2basics.domain.project.dto.response.ProjectUpdateResponse;
 import com.back2basics.project.port.in.CreateProjectUseCase;
 import com.back2basics.project.port.in.DeleteProjectUseCase;
 import com.back2basics.project.port.in.GetProjectUseCase;
@@ -9,14 +13,18 @@ import com.back2basics.project.port.in.command.ProjectCreateCommand;
 import com.back2basics.project.port.in.command.ProjectResponseDto;
 import com.back2basics.project.port.in.command.ProjectUpdateCommand;
 import com.back2basics.domain.project.controller.code.ProjectResponseCode;
+import com.back2basics.project.service.result.ProjectGetResult;
+import com.back2basics.project.service.result.ProjectUpdateResult;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,31 +42,37 @@ public class ProjectController {
 
     @PostMapping()
     public ResponseEntity<ApiResponse<Void>> createProject(
-        @RequestBody @Valid ProjectCreateCommand command) {
+        @RequestBody @Valid ProjectCreateRequest request) {
+        ProjectCreateCommand command = request.toCommand();
         createProjectUseCase.createProject(command);
         return ApiResponse.success(ProjectResponseCode.PROJECT_CREATE_SUCCESS);
     }
 
     @GetMapping("/{projectId}")
-    public ResponseEntity<ApiResponse<ProjectResponseDto>> getProjectById(
+    public ResponseEntity<ApiResponse<ProjectGetResponse>> getProjectById(
         @PathVariable Long projectId) {
-        ProjectResponseDto projectDto = getProjectUseCase.getProjectById(projectId);
-        return ApiResponse.success(ProjectResponseCode.PROJECT_READ_SUCCESS, projectDto);
+        ProjectGetResult result = getProjectUseCase.getProjectById(projectId);
+        ProjectGetResponse response = ProjectGetResponse.toResponse(result);
+        return ApiResponse.success(ProjectResponseCode.PROJECT_READ_SUCCESS, response);
     }
 
     @GetMapping()
-    public ResponseEntity<ApiResponse<List<ProjectResponseDto>>> getAllProjects() {
-        List<ProjectResponseDto> list = getProjectUseCase.getAllProjects();
+    public ResponseEntity<ApiResponse<List<ProjectGetResponse>>> getAllProjects() {
+        List<ProjectGetResult> result = getProjectUseCase.getAllProjects();
+        List<ProjectGetResponse> list = result.stream().map(ProjectGetResponse::toResponse)
+            .collect(Collectors.toList());
         return ApiResponse.success(ProjectResponseCode.PROJECT_READ_ALL_SUCCESS, list);
     }
 
-    // todo : 수정로그체크하려면 id , 변경사항 리턴
-    @PatchMapping("/{projectId}")
-    public ResponseEntity<ApiResponse<Void>> updateProject(
+    // todo : response 에는 updatedAt 이 반영이 안됨. get 에서 반영된 response 출력
+    @PutMapping("/{projectId}")
+    public ResponseEntity<ApiResponse<ProjectUpdateResponse>> updateProject(
         @PathVariable Long projectId,
-        @RequestBody @Valid ProjectUpdateCommand command) {
-        updateProjectUseCase.updateProject(projectId, command);
-        return ApiResponse.success(ProjectResponseCode.PROJECT_UPDATE_SUCCESS);
+        @RequestBody @Valid ProjectUpdateRequest request) {
+        ProjectUpdateCommand command = request.toCommand();
+        ProjectUpdateResult result = updateProjectUseCase.updateProject(projectId, command);
+        ProjectUpdateResponse response = ProjectUpdateResponse.toResponse(result);
+        return ApiResponse.success(ProjectResponseCode.PROJECT_UPDATE_SUCCESS, response);
     }
 
     @PatchMapping("/{projectId}/delete")
@@ -68,9 +82,10 @@ public class ProjectController {
     }
 
     @PatchMapping("/{projectId}/status")
-    public ResponseEntity<ApiResponse<ProjectResponseDto>> changedStatus(
+    public ResponseEntity<ApiResponse<ProjectUpdateResponse>> changedStatus(
         @PathVariable Long projectId) {
-        ProjectResponseDto dto = updateProjectUseCase.changedStatus(projectId);
-        return ApiResponse.success(ProjectResponseCode.PROJECT_UPDATE_SUCCESS, dto);
+        ProjectUpdateResult result = updateProjectUseCase.changedStatus(projectId);
+        ProjectUpdateResponse response = ProjectUpdateResponse.toResponse(result);
+        return ApiResponse.success(ProjectResponseCode.PROJECT_UPDATE_SUCCESS, response);
     }
 }

--- a/module-api/src/main/java/com/back2basics/domain/project/controller/ProjectController.java
+++ b/module-api/src/main/java/com/back2basics/domain/project/controller/ProjectController.java
@@ -32,7 +32,7 @@ public class ProjectController {
     private final DeleteProjectUseCase deleteProjectUseCase;
 
 
-    @PostMapping("")
+    @PostMapping()
     public ResponseEntity<ApiResponse<Void>> createProject(
         @RequestBody @Valid ProjectCreateCommand command) {
         createProjectUseCase.createProject(command);
@@ -46,7 +46,7 @@ public class ProjectController {
         return ApiResponse.success(ProjectResponseCode.PROJECT_READ_SUCCESS, projectDto);
     }
 
-    @GetMapping("")
+    @GetMapping()
     public ResponseEntity<ApiResponse<List<ProjectResponseDto>>> getAllProjects() {
         List<ProjectResponseDto> list = getProjectUseCase.getAllProjects();
         return ApiResponse.success(ProjectResponseCode.PROJECT_READ_ALL_SUCCESS, list);
@@ -65,5 +65,12 @@ public class ProjectController {
     public ResponseEntity<ApiResponse<Void>> deleteProject(@PathVariable Long projectId) {
         deleteProjectUseCase.deleteProject(projectId);
         return ApiResponse.success(ProjectResponseCode.PROJECT_DELETE_SUCCESS);
+    }
+
+    @PatchMapping("/{projectId}/status")
+    public ResponseEntity<ApiResponse<ProjectResponseDto>> changedStatus(
+        @PathVariable Long projectId) {
+        ProjectResponseDto dto = updateProjectUseCase.changedStatus(projectId);
+        return ApiResponse.success(ProjectResponseCode.PROJECT_UPDATE_SUCCESS, dto);
     }
 }

--- a/module-api/src/main/java/com/back2basics/domain/project/dto/request/ProjectUpdateRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/project/dto/request/ProjectUpdateRequest.java
@@ -1,14 +1,14 @@
 package com.back2basics.domain.project.dto.request;
 
-import com.back2basics.project.port.in.command.ProjectCreateCommand;
+import com.back2basics.project.port.in.command.ProjectUpdateCommand;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDate;
 
-public record ProjectCreateRequest(@NotBlank(message = "프로젝트명은 필수입니다.") String name,
+public record ProjectUpdateRequest(@NotBlank(message = "프로젝트명은 필수입니다.") String name,
                                    String description, LocalDate startDate, LocalDate endDate) {
 
-    public ProjectCreateCommand toCommand() {
-        return ProjectCreateCommand.builder()
+    public ProjectUpdateCommand toCommand() {
+        return ProjectUpdateCommand.builder()
             .name(name)
             .description(description)
             .startDate(startDate)

--- a/module-api/src/main/java/com/back2basics/domain/project/dto/response/ProjectGetResponse.java
+++ b/module-api/src/main/java/com/back2basics/domain/project/dto/response/ProjectGetResponse.java
@@ -1,0 +1,18 @@
+package com.back2basics.domain.project.dto.response;
+
+import com.back2basics.project.model.ProjectStatus;
+import com.back2basics.project.service.result.ProjectGetResult;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ProjectGetResponse(Long id, String name, String description,
+                                 LocalDate startDate, LocalDate endDate, LocalDateTime createdAt,
+                                 LocalDateTime updatedAt, LocalDateTime deletedAt,
+                                 boolean isDeleted, ProjectStatus status) {
+
+    public static ProjectGetResponse toResponse(ProjectGetResult result) {
+        return new ProjectGetResponse(result.getId(), result.getName(), result.getDescription(),
+            result.getStartDate(), result.getEndDate(), result.getCreatedAt(),
+            result.getUpdatedAt(), result.getDeletedAt(), result.isDeleted(), result.getStatus());
+    }
+}

--- a/module-api/src/main/java/com/back2basics/domain/project/dto/response/ProjectUpdateResponse.java
+++ b/module-api/src/main/java/com/back2basics/domain/project/dto/response/ProjectUpdateResponse.java
@@ -1,19 +1,20 @@
 package com.back2basics.domain.project.dto.response;
 
-import com.back2basics.domain.project.dto.request.ProjectCreateRequest;
 import com.back2basics.project.model.ProjectStatus;
 import com.back2basics.project.service.result.ProjectCreateResult;
+import com.back2basics.project.service.result.ProjectUpdateResult;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-public record ProjectCreateResponse(Long id, String name, String description,
+public record ProjectUpdateResponse(Long id, String name, String description,
                                     LocalDate startDate, LocalDate endDate, LocalDateTime createdAt,
                                     LocalDateTime updatedAt, LocalDateTime deletedAt,
                                     boolean isDeleted, ProjectStatus status) {
 
-    public static ProjectCreateResponse toResponse(ProjectCreateResult result) {
-        return new ProjectCreateResponse(result.getId(), result.getName(), result.getDescription(),
+    public static ProjectUpdateResponse toResponse(ProjectUpdateResult result) {
+        return new ProjectUpdateResponse(result.getId(), result.getName(), result.getDescription(),
             result.getStartDate(), result.getEndDate(), result.getCreatedAt(),
             result.getUpdatedAt(), result.getDeletedAt(), result.isDeleted(), result.getStatus());
     }
+
 }

--- a/module-core/src/main/java/com/back2basics/infra/validation/validator/ProjectValidator.java
+++ b/module-core/src/main/java/com/back2basics/infra/validation/validator/ProjectValidator.java
@@ -4,6 +4,7 @@ import com.back2basics.project.model.Project;
 import com.back2basics.project.port.out.ProjectRepositoryPort;
 import com.back2basics.infra.exception.project.ProjectErrorCode;
 import com.back2basics.infra.exception.project.ProjectException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,8 +14,18 @@ public class ProjectValidator {
 
     private final ProjectRepositoryPort projectRepositoryPort;
 
-    public Project findProject(Long id) {
+    public Project findProjectById(Long id) {
         return projectRepositoryPort.findById(id)
             .orElseThrow(() -> new ProjectException(ProjectErrorCode.PROJECT_NOT_FOUND));
+    }
+
+    public List<Project> findProject() {
+        List<Project> projects = projectRepositoryPort.findAll();
+
+        if (projects.isEmpty()) {
+            throw new ProjectException(ProjectErrorCode.PROJECT_NOT_FOUND);
+        }
+
+        return projects;
     }
 }

--- a/module-core/src/main/java/com/back2basics/project/model/Project.java
+++ b/module-core/src/main/java/com/back2basics/project/model/Project.java
@@ -1,5 +1,6 @@
 package com.back2basics.project.model;
 
+import com.back2basics.post.model.PostStatus;
 import com.back2basics.project.port.in.command.ProjectUpdateCommand;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -28,9 +29,12 @@ public class Project {
 
     private boolean isDeleted;
 
+    private ProjectStatus status;
+
     @Builder
     public Project(Long id, String name, String description, LocalDate startDate, LocalDate endDate,
-        LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, boolean isDeleted) {
+        LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt,
+        boolean isDeleted, ProjectStatus status) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -39,9 +43,11 @@ public class Project {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.deletedAt = deletedAt;
-        this.isDeleted = isDeleted;
+        this.isDeleted = false;
+        this.status = status != null ? status : ProjectStatus.IN_PROGRESS;
     }
 
+    // todo: http 메서드 put으로 변경, null 체크 안함
     public void update(ProjectUpdateCommand command) {
         if (command.getName() != null) {
             this.name = command.getName();
@@ -57,9 +63,17 @@ public class Project {
         }
     }
 
+    // todo: project 상태변경
+    public void statusCompleted(){
+        this.status = ProjectStatus.COMPLETED;
+
+    }public void statusInProgress(){
+        this.status = ProjectStatus.IN_PROGRESS;
+    }
+
     // 삭제를 더 직관적이게 나타내기 위헤 isDeleted 추가
-//    public void softDeleted() {
-//        this.isDeleted = true; // 만약 도메인에서 localDatetime을 변경한다면 entity에도 isDeleted 추가하는거 어떨지..
-//        this.deletedAt = LocalDateTime.now();
-//    }
+    public void softDeleted() {
+        this.isDeleted = true; // 만약 도메인에서 localDatetime을 변경한다면 entity에도 isDeleted 추가하는거 어떨지..
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/module-core/src/main/java/com/back2basics/project/model/Project.java
+++ b/module-core/src/main/java/com/back2basics/project/model/Project.java
@@ -49,18 +49,10 @@ public class Project {
 
     // todo: http 메서드 put으로 변경, null 체크 안함
     public void update(ProjectUpdateCommand command) {
-        if (command.getName() != null) {
-            this.name = command.getName();
-        }
-        if (command.getDescription() != null) {
-            this.description = command.getDescription();
-        }
-        if (command.getStartDate() != null) {
-            this.startDate = command.getStartDate();
-        }
-        if (command.getEndDate() != null) {
-            this.endDate = command.getEndDate();
-        }
+        this.name = command.getName();
+        this.description = command.getDescription();
+        this.startDate = command.getStartDate();
+        this.endDate = command.getEndDate();
     }
 
     // todo: project 상태변경

--- a/module-core/src/main/java/com/back2basics/project/model/ProjectStatus.java
+++ b/module-core/src/main/java/com/back2basics/project/model/ProjectStatus.java
@@ -1,0 +1,6 @@
+package com.back2basics.project.model;
+
+public enum ProjectStatus {
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/module-core/src/main/java/com/back2basics/project/port/in/GetProjectUseCase.java
+++ b/module-core/src/main/java/com/back2basics/project/port/in/GetProjectUseCase.java
@@ -1,18 +1,19 @@
 package com.back2basics.project.port.in;
 
 import com.back2basics.project.port.in.command.ProjectResponseDto;
+import com.back2basics.project.service.result.ProjectGetResult;
 import java.util.List;
 
 public interface GetProjectUseCase {
 
     /* 프로젝트 상세 조회 */
-    ProjectResponseDto getProjectById(Long projectId);
+    ProjectGetResult getProjectById(Long projectId);
 
     /* 관리자용 전체 리스트 (나중에 검색 -> 카테고리 : 프로젝트명, 회원명)
         프로젝트 상태 -> 전체, 진행중, 완료 */
-    List<ProjectResponseDto> getAllProjects();
+    List<ProjectGetResult> getAllProjects();
 
     /* 회원용 전체 리스트 (나중에 검색 -> 카테고리 : 프로젝트명)
         프로젝트 상태 -> 전체, 진행중, 완료 */
-    List<ProjectResponseDto> getAllProjectsByUserId(Long userId);
+    List<ProjectGetResult> getAllProjectsByUserId(Long userId);
 }

--- a/module-core/src/main/java/com/back2basics/project/port/in/UpdateProjectUseCase.java
+++ b/module-core/src/main/java/com/back2basics/project/port/in/UpdateProjectUseCase.java
@@ -6,4 +6,6 @@ import com.back2basics.project.port.in.command.ProjectUpdateCommand;
 public interface UpdateProjectUseCase {
 
     ProjectResponseDto updateProject(Long projectId, ProjectUpdateCommand projectUpdateCommand);
+
+    ProjectResponseDto changedStatus(Long projectId);
 }

--- a/module-core/src/main/java/com/back2basics/project/port/in/UpdateProjectUseCase.java
+++ b/module-core/src/main/java/com/back2basics/project/port/in/UpdateProjectUseCase.java
@@ -2,10 +2,11 @@ package com.back2basics.project.port.in;
 
 import com.back2basics.project.port.in.command.ProjectResponseDto;
 import com.back2basics.project.port.in.command.ProjectUpdateCommand;
+import com.back2basics.project.service.result.ProjectUpdateResult;
 
 public interface UpdateProjectUseCase {
 
-    ProjectResponseDto updateProject(Long projectId, ProjectUpdateCommand projectUpdateCommand);
+    ProjectUpdateResult updateProject(Long projectId, ProjectUpdateCommand projectUpdateCommand);
 
-    ProjectResponseDto changedStatus(Long projectId);
+    ProjectUpdateResult changedStatus(Long projectId);
 }

--- a/module-core/src/main/java/com/back2basics/project/port/in/command/ProjectCreateCommand.java
+++ b/module-core/src/main/java/com/back2basics/project/port/in/command/ProjectCreateCommand.java
@@ -3,12 +3,12 @@ package com.back2basics.project.port.in.command;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
 public class ProjectCreateCommand {
 
     @NotBlank(message = "프로젝트명은 필수입니다.")

--- a/module-core/src/main/java/com/back2basics/project/port/in/command/ProjectResponseDto.java
+++ b/module-core/src/main/java/com/back2basics/project/port/in/command/ProjectResponseDto.java
@@ -1,6 +1,7 @@
 package com.back2basics.project.port.in.command;
 
 import com.back2basics.project.model.Project;
+import com.back2basics.project.model.ProjectStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -24,9 +25,13 @@ public class ProjectResponseDto {
 
     private final LocalDateTime deletedAt;
 
+    private final boolean isDeleted;
+
+    private final ProjectStatus status;
+
     @Builder
     public ProjectResponseDto(Long id, String name, String description, LocalDate startDate, LocalDate endDate,
-        LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, boolean isDeleted, ProjectStatus status) {
         this.id = id;
         this.name = name;
         this.description = description;
@@ -35,6 +40,8 @@ public class ProjectResponseDto {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.deletedAt = deletedAt;
+        this.isDeleted = isDeleted;
+        this.status = status;
     }
 
     public static ProjectResponseDto from(Project project) {
@@ -47,6 +54,8 @@ public class ProjectResponseDto {
             .createdAt(project.getCreatedAt())
             .updatedAt(project.getUpdatedAt())
             .deletedAt(project.getDeletedAt())
+            .isDeleted(project.isDeleted())
+            .status(project.getStatus())
             .build();
     }
 }

--- a/module-core/src/main/java/com/back2basics/project/port/in/command/ProjectUpdateCommand.java
+++ b/module-core/src/main/java/com/back2basics/project/port/in/command/ProjectUpdateCommand.java
@@ -3,12 +3,12 @@ package com.back2basics.project.port.in.command;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDate;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
 public class ProjectUpdateCommand {
 
     // todo : custom

--- a/module-core/src/main/java/com/back2basics/project/service/ProjectServiceImpl.java
+++ b/module-core/src/main/java/com/back2basics/project/service/ProjectServiceImpl.java
@@ -1,6 +1,7 @@
 package com.back2basics.project.service;
 
 import com.back2basics.project.model.Project;
+import com.back2basics.project.model.ProjectStatus;
 import com.back2basics.project.port.in.CreateProjectUseCase;
 import com.back2basics.project.port.in.DeleteProjectUseCase;
 import com.back2basics.project.port.in.GetProjectUseCase;
@@ -34,10 +35,11 @@ public class ProjectServiceImpl implements
             .startDate(command.getStartDate())
             .endDate(command.getEndDate())
             .isDeleted(false)
-            .build(); // todo: 여기서 build
+            .build();
         projectRepositoryPort.save(project);
     }
 
+    // todo : get 조건 - isDeleted false, filtering - status IN_PROGRESS / COMPLETED
     @Override
     public ProjectResponseDto getProjectById(Long id) {
         Project project = projectValidator.findProject(id);
@@ -66,10 +68,24 @@ public class ProjectServiceImpl implements
         return ProjectResponseDto.from(project);
     }
 
+    // todo : softDelete 의견 공유
     @Override
     public void deleteProject(Long id) {
         Project project = projectValidator.findProject(id);
-        // project.softDeleted();
+        project.softDeleted();
         projectRepositoryPort.update(project);
+    }
+
+    @Override
+    public ProjectResponseDto changedStatus(Long projectId) {
+        Project project = projectValidator.findProject(projectId);
+
+        if (project.getStatus().equals(ProjectStatus.IN_PROGRESS)) {
+            project.statusCompleted();
+        } else {
+            project.statusInProgress();
+        }
+        projectRepositoryPort.update(project);
+        return ProjectResponseDto.from(project);
     }
 }

--- a/module-core/src/main/java/com/back2basics/project/service/ProjectServiceImpl.java
+++ b/module-core/src/main/java/com/back2basics/project/service/ProjectServiceImpl.java
@@ -11,6 +11,8 @@ import com.back2basics.project.port.in.command.ProjectCreateCommand;
 import com.back2basics.project.port.in.command.ProjectResponseDto;
 import com.back2basics.project.port.in.command.ProjectUpdateCommand;
 import com.back2basics.infra.validation.validator.ProjectValidator;
+import com.back2basics.project.service.result.ProjectGetResult;
+import com.back2basics.project.service.result.ProjectUpdateResult;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -41,51 +43,52 @@ public class ProjectServiceImpl implements
 
     // todo : get 조건 - isDeleted false, filtering - status IN_PROGRESS / COMPLETED
     @Override
-    public ProjectResponseDto getProjectById(Long id) {
-        Project project = projectValidator.findProject(id);
-        return ProjectResponseDto.from(project);
+    public ProjectGetResult getProjectById(Long id) {
+        Project project = projectValidator.findProjectById(id);
+        return ProjectGetResult.toResult(project);
     }
 
     @Override
-    public List<ProjectResponseDto> getAllProjects() {
-        return projectRepositoryPort.findAll().stream()
-            .map(ProjectResponseDto::from)
+    public List<ProjectGetResult> getAllProjects() {
+        return projectValidator.findProject().stream()
+            .map(ProjectGetResult::toResult)
             .collect(Collectors.toList());
     }
 
     @Override
-    public List<ProjectResponseDto> getAllProjectsByUserId(Long userId) {
+    public List<ProjectGetResult> getAllProjectsByUserId(Long userId) {
         return List.of();
     }
 
     // todo : 사용자 인증 로직 추가
     @Override
-    public ProjectResponseDto updateProject(Long id,
+    public ProjectUpdateResult updateProject(Long id,
         ProjectUpdateCommand projectUpdateCommand) {
-        Project project = projectValidator.findProject(id);
+        Project project = projectValidator.findProjectById(id);
         project.update(projectUpdateCommand);
         projectRepositoryPort.update(project);
-        return ProjectResponseDto.from(project);
+        return ProjectUpdateResult.toResult(project);
     }
 
     // todo : softDelete 의견 공유
     @Override
     public void deleteProject(Long id) {
-        Project project = projectValidator.findProject(id);
+        Project project = projectValidator.findProjectById(id);
         project.softDeleted();
         projectRepositoryPort.update(project);
     }
 
+    // todo: equals 비교연산자로 변경
     @Override
-    public ProjectResponseDto changedStatus(Long projectId) {
-        Project project = projectValidator.findProject(projectId);
+    public ProjectUpdateResult changedStatus(Long projectId) {
+        Project project = projectValidator.findProjectById(projectId);
 
-        if (project.getStatus().equals(ProjectStatus.IN_PROGRESS)) {
+        if (project.getStatus() == ProjectStatus.IN_PROGRESS) {
             project.statusCompleted();
         } else {
             project.statusInProgress();
         }
         projectRepositoryPort.update(project);
-        return ProjectResponseDto.from(project);
+        return ProjectUpdateResult.toResult(project);
     }
 }

--- a/module-core/src/main/java/com/back2basics/project/service/result/ProjectCreateResult.java
+++ b/module-core/src/main/java/com/back2basics/project/service/result/ProjectCreateResult.java
@@ -1,5 +1,23 @@
 package com.back2basics.project.service.result;
 
+import com.back2basics.project.model.ProjectStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
 public class ProjectCreateResult {
-    // example
+
+    private final Long id;
+    private final String name;
+    private final String description;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final LocalDateTime deletedAt;
+    private final boolean isDeleted;
+    private final ProjectStatus status;
 }

--- a/module-core/src/main/java/com/back2basics/project/service/result/ProjectGetResult.java
+++ b/module-core/src/main/java/com/back2basics/project/service/result/ProjectGetResult.java
@@ -1,0 +1,48 @@
+package com.back2basics.project.service.result;
+
+import com.back2basics.project.model.Project;
+import com.back2basics.project.model.ProjectStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProjectGetResult {
+
+    private final Long id;
+
+    private final String name;
+
+    private final String description;
+
+    private final LocalDate startDate;
+
+    private final LocalDate endDate;
+
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime updatedAt;
+
+    private final LocalDateTime deletedAt;
+
+    private final boolean isDeleted;
+
+    private final ProjectStatus status;
+
+    public  static ProjectGetResult toResult(Project project) {
+        return ProjectGetResult.builder()
+            .id(project.getId())
+            .name(project.getName())
+            .description(project.getDescription())
+            .startDate(project.getStartDate())
+            .endDate(project.getEndDate())
+            .createdAt(project.getCreatedAt())
+            .updatedAt(project.getUpdatedAt())
+            .deletedAt(project.getDeletedAt())
+            .isDeleted(project.isDeleted())
+            .status(project.getStatus())
+            .build();
+    }
+}

--- a/module-core/src/main/java/com/back2basics/project/service/result/ProjectUpdateResult.java
+++ b/module-core/src/main/java/com/back2basics/project/service/result/ProjectUpdateResult.java
@@ -1,0 +1,38 @@
+package com.back2basics.project.service.result;
+
+import com.back2basics.project.model.Project;
+import com.back2basics.project.model.ProjectStatus;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProjectUpdateResult {
+    private final Long id;
+    private final String name;
+    private final String description;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final LocalDateTime deletedAt;
+    private final boolean isDeleted;
+    private final ProjectStatus status;
+
+    public  static ProjectUpdateResult toResult(Project project) {
+        return ProjectUpdateResult.builder()
+            .id(project.getId())
+            .name(project.getName())
+            .description(project.getDescription())
+            .startDate(project.getStartDate())
+            .endDate(project.getEndDate())
+            .createdAt(project.getCreatedAt())
+            .updatedAt(project.getUpdatedAt())
+            .deletedAt(project.getDeletedAt())
+            .isDeleted(project.isDeleted())
+            .status(project.getStatus())
+            .build();
+    }
+}

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/project/adapter/out/ProjectJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/project/adapter/out/ProjectJpaAdapter.java
@@ -26,12 +26,16 @@ public class ProjectJpaAdapter implements ProjectRepositoryPort {
 
     @Override
     public Optional<Project> findById(Long id) {
-        return projectEntityRepository.findById(id).map(projectMapper::toDomain);
+        return projectEntityRepository.findById(id)
+            .filter(it -> !it.isDeleted())
+            .map(projectMapper::toDomain);
     }
 
     @Override
     public List<Project> findAll() {
-        return projectEntityRepository.findAll().stream()
+        return projectEntityRepository.findAll()
+            .stream()
+            .filter(it -> !it.isDeleted())
             .map(projectMapper::toDomain)
             .collect(Collectors.toList());
     }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/project/entity/ProjectEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/project/entity/ProjectEntity.java
@@ -1,8 +1,11 @@
 package com.back2basics.adapter.persistence.project.entity;
 
 import com.back2basics.adapter.persistence.common.entity.BaseTimeEntity;
+import com.back2basics.project.model.ProjectStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -44,10 +47,13 @@ public class ProjectEntity extends BaseTimeEntity {
     @Column(name = "is_deleted")
     private boolean isDeleted;
 
-    @Builder
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private ProjectStatus status;
 
+    @Builder
     public ProjectEntity(Long id, String name, String description, LocalDate startDate,
-        LocalDate endDate, LocalDateTime deletedAt, boolean isDeleted) {
+        LocalDate endDate, LocalDateTime deletedAt, boolean isDeleted, ProjectStatus status) {
 
         this.id = id;
         this.name = name;
@@ -56,5 +62,6 @@ public class ProjectEntity extends BaseTimeEntity {
         this.endDate = endDate;
         this.deletedAt = deletedAt;
         this.isDeleted = isDeleted;
+        this.status = status;
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/project/mapper/ProjectMapper.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/project/mapper/ProjectMapper.java
@@ -18,6 +18,7 @@ public class ProjectMapper {
             .updatedAt(projectEntity.getUpdatedAt())
             .deletedAt(projectEntity.getDeletedAt())
             .isDeleted(projectEntity.isDeleted())
+            .status(projectEntity.getStatus())
             .build();
     }
 
@@ -30,6 +31,7 @@ public class ProjectMapper {
             .endDate(project.getEndDate())
             .deletedAt(project.getDeletedAt())
             .isDeleted(project.isDeleted())
+            .status(project.getStatus())
             .build();
     }
 }


### PR DESCRIPTION
## 📌 개요
삭제되지 않은 게시글만 조회
프로젝트 상태 변경 추가
요청/응답 객체 추가

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 게시글 조회시 삭제되지 않은 게시글만 조회할 수 있도록 하였습니다.
- 프로젝트 상태 ( 진행중, 완료 )를 추가하였고
프로젝트 상태를 진행중인 경우 완료, 완료인 경우 진행중으로 바꿀 수 있도록 하였습니다.
- web, core 계층에서 사용하는 요청/응답 객체를 나눴습니다.

## 🔍 관련 이슈
<!-- 예: Close #12 -->
- Close #
- See also #

## 🧪 테스트 결과
postman 정상 동작

## 👀 리뷰어에게 요청사항
- `ProjectServiceImpl`에 `changedStatus` 메서드의 `project.getStatus().equals(ProjectStatus.IN_PROGRESS`는
비교연산자 `==`을 사용하여 바꿀 예정인데 의견 있으시면 리뷰 남겨주세요 😀

## 📎 기타 참고 사항
- 삭제(softDeleted) 관련 코드는 아직 의견을 나누지 못했다고 생각하여 제 코드에서만 동작할 것 같습니다.
- controller와 service 요청/응답 객체는 아직 변경하지 못하였습니다.
