### PR TITLE
[Fix] Company 조회 시 email, tel이 null값으로 나오던 현상 수정

### DIFF
--- a/module-core/src/main/java/com/back2basics/company/service/result/CompanyInfoResult.java
+++ b/module-core/src/main/java/com/back2basics/company/service/result/CompanyInfoResult.java
@@ -42,6 +42,8 @@ public class CompanyInfoResult {
             .companyType(company.getCompanyType())
             .bizNo(company.getBizNo())
             .address(company.getAddress())
+            .email(company.getEmail())
+            .tel(company.getTel())
             .build();
     }
 }


### PR DESCRIPTION
## 📌 개요
CompanyInfoResult에서 도메인 객체를 받아올 때 email, tel 누락 확인

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [X] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
email, tel 추가

## 🔍 관련 이슈
<!-- 예: Close #12 -->
- Close #83 
- See also #

## 🧪 테스트 결과
Talend를 통한 확인
![image](https://github.com/user-attachments/assets/230cf5f6-6e46-447b-b4ec-ddb4c0c92de4)


## 👀 리뷰어에게 요청사항
버그 수정하였습니다.

## 📎 기타 참고 사항

