### PR TITLE
[Feature] 게시글 페이지네이션 적용

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/post/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/post/controller/PostController.java
@@ -16,6 +16,7 @@ import com.back2basics.post.service.result.PostReadResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 
@@ -54,8 +56,13 @@ public class PostController {
         return ApiResponse.success(PostResponseCode.POST_READ_SUCCESS, response);
     }
 
-    @GetMapping()
-    public ResponseEntity<ApiResponse<Page<PostReadResponse>>> getPostsByPaging(Pageable pageable) {
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<PostReadResponse>>> getPostsByPaging(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+
         Page<PostReadResult> resultPage = postReadUseCase.getPostList(pageable);
         Page<PostReadResponse> responsePage = resultPage.map(PostReadResponse::toResponse);
 

--- a/module-api/src/main/java/com/back2basics/domain/post/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/post/controller/PostController.java
@@ -14,9 +14,9 @@ import com.back2basics.post.port.in.PostUpdateUseCase;
 import com.back2basics.post.service.result.PostCreateResult;
 import com.back2basics.post.service.result.PostReadResult;
 import jakarta.validation.Valid;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,14 +54,12 @@ public class PostController {
         return ApiResponse.success(PostResponseCode.POST_READ_SUCCESS, response);
     }
 
-    @GetMapping
-    public ResponseEntity<ApiResponse<List<PostReadResponse>>> getAllPosts() {
-        List<PostReadResult> resultList = postReadUseCase.getPostList();
-        List<PostReadResponse> responseList = resultList.stream()
-            .map(PostReadResponse::toResponse)
-            .collect(Collectors.toList());
+    @GetMapping()
+    public ResponseEntity<ApiResponse<Page<PostReadResponse>>> getPostsByPaging(Pageable pageable) {
+        Page<PostReadResult> resultPage = postReadUseCase.getPostList(pageable);
+        Page<PostReadResponse> responsePage = resultPage.map(PostReadResponse::toResponse);
 
-        return ApiResponse.success(PostResponseCode.POST_READ_ALL_SUCCESS, responseList);
+        return ApiResponse.success(PostResponseCode.POST_READ_ALL_SUCCESS, responsePage);
     }
 
     @PutMapping("/{postId}")

--- a/module-api/src/main/java/com/back2basics/global/config/WebConfig.java
+++ b/module-api/src/main/java/com/back2basics/global/config/WebConfig.java
@@ -1,0 +1,11 @@
+package com.back2basics.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode;
+
+@Configuration
+@EnableSpringDataWebSupport(pageSerializationMode = PageSerializationMode.VIA_DTO)
+public class WebConfig {
+
+}

--- a/module-core/build.gradle
+++ b/module-core/build.gradle
@@ -4,10 +4,14 @@ plugins {
 
 dependencies {
 
+    // jpa
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    
     implementation 'org.springframework.boot:spring-boot-starter-web'
 //    implementation 'org.springframework.boot:spring-boot-starter-mail'
     // module
     implementation project(':module-common')
+
 }
 
 bootJar {

--- a/module-core/src/main/java/com/back2basics/post/port/in/PostReadUseCase.java
+++ b/module-core/src/main/java/com/back2basics/post/port/in/PostReadUseCase.java
@@ -1,11 +1,12 @@
 package com.back2basics.post.port.in;
 
 import com.back2basics.post.service.result.PostReadResult;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface PostReadUseCase {
 
     PostReadResult getPost(Long id);
 
-    List<PostReadResult> getPostList();
+    Page<PostReadResult> getPostList(Pageable pageable);
 }

--- a/module-core/src/main/java/com/back2basics/post/port/out/PostReadPort.java
+++ b/module-core/src/main/java/com/back2basics/post/port/out/PostReadPort.java
@@ -1,12 +1,13 @@
 package com.back2basics.post.port.out;
 
 import com.back2basics.post.model.Post;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface PostReadPort {
 
     Optional<Post> findById(Long id);
 
-    List<Post> findAll();
+    Page<Post> findAllWithPaging(Pageable pageable);
 }

--- a/module-core/src/main/java/com/back2basics/post/service/PostReadService.java
+++ b/module-core/src/main/java/com/back2basics/post/service/PostReadService.java
@@ -5,9 +5,9 @@ import com.back2basics.post.model.Post;
 import com.back2basics.post.port.in.PostReadUseCase;
 import com.back2basics.post.port.out.PostReadPort;
 import com.back2basics.post.service.result.PostReadResult;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,9 +24,8 @@ public class PostReadService implements PostReadUseCase {
     }
 
     @Override
-    public List<PostReadResult> getPostList() {
-        return postReadPort.findAll().stream()
-            .map(PostReadResult::toResult)
-            .collect(Collectors.toList());
+    public Page<PostReadResult> getPostList(Pageable pageable) {
+        return postReadPort.findAllWithPaging(pageable)
+            .map(PostReadResult::toResult);
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/post/PostEntityRepository.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/post/PostEntityRepository.java
@@ -1,21 +1,46 @@
 package com.back2basics.adapter.persistence.post;
 
 import java.util.List;
-import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostEntityRepository extends JpaRepository<PostEntity, Long> {
 
-    @Query("SELECT p FROM PostEntity p LEFT JOIN FETCH p.comments WHERE p.id = :id AND p.deletedAt IS NULL")
-    Optional<PostEntity> findActivePostWithComments(@Param("id") Long id);
+    // 전체 게시글 페이지네이션(삭제안된애들 최신순)
+    // 1. id로 페이징 쿼리
+    /*
+        select p.id
+        from post p
+        where p.deleted_at is null
+        order by p.created_at desc, p.id desc
+     */
+    @Query("SELECT p.id FROM PostEntity p WHERE p.deletedAt IS NULL ORDER BY p.createdAt DESC, p.id DESC")
+    List<Long> findActivePostIds(Pageable pageable);
 
-    @Query("SELECT p FROM PostEntity p WHERE p.deletedAt IS NULL")
-    List<PostEntity> findAllActivePosts();
+    // 2. id로 연관 엔티티 조인(in쿼리 : fetch join)
+    /*
+        select p.*, c.*
+        from post p
+        left join comment c on c.post_id = p.id
+        where p.deleted_at is null
+        order by p.created_at desc, p.id desc
+     */
+    @Query("SELECT DISTINCT p FROM PostEntity p " +
+        "LEFT JOIN FETCH p.comments c " +
+        "WHERE p.id IN :postIds AND p.deletedAt IS NULL " +
+        "ORDER BY p.createdAt DESC, p.id DESC")
+    List<PostEntity> findActivePostsWithCommentsByIds(List<Long> postIds);
 
-    @Query("SELECT p FROM PostEntity p WHERE p.id = :id AND p.deletedAt IS NULL")
-    Optional<PostEntity> findActivePostById(@Param("id") Long id);
+    // 3. 카운트 쿼리(total)
+    /*
+        select count(p)
+        from post p
+        where p.deleted_at is null
+     */
+    @Query("SELECT COUNT(p) FROM PostEntity p WHERE p.deletedAt IS NULL")
+    long countActivePosts();
+
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/post/adapter/PostReadJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/post/adapter/PostReadJpaAdapter.java
@@ -8,25 +8,38 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class PostReadJpaAdapter implements PostReadPort {
 
+
     private final PostEntityRepository postRepository;
     private final PostMapper mapper;
 
     @Override
-    public Optional<Post> findById(Long id) {
-        return postRepository.findById(id).map(mapper::toDomain);
+    public Page<Post> findAllWithPaging(Pageable pageable) {
+
+        // id 페이징
+        List<Long> ids = postRepository.findActivePostIds(pageable);
+
+        // fetch join 쿼리
+        List<Post> posts = postRepository.findActivePostsWithCommentsByIds(ids).stream()
+            .map(mapper::toDomain)
+            .collect(Collectors.toList());
+
+        // 카운트 쿼리
+        long total = postRepository.countActivePosts();
+        return new PageImpl<>(posts, pageable, total);
     }
 
     @Override
-    public List<Post> findAll() {
-        return postRepository.findAll().stream()
-            .map(mapper::toDomain)
-            .collect(Collectors.toList());
+    public Optional<Post> findById(Long id) {
+        return postRepository.findById(id).map(mapper::toDomain);
     }
 
 }


### PR DESCRIPTION
## 📌 개요
- 게시글 목록 조회에 페이지네이션 적용

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 댓글엔티티와 `@OneToMany`가 걸려있는 문제로 인해 고려해야할 점
   - N+1 해결 하고싶어서 fetch join 쓰면 실제로는 메모리에 모두 로드된 후 리턴되는 현상 발생
   - `id 페이징 + fetch join쿼리(in절날라감) + 카운트쿼리` 총 3단계로 구분하여 메소드 구현
- `Page<Object>` 로 리턴 받을 시 권장되지 않는 사항이라는 `warning` 문구 해결
   - `@EnableSpringDataWebSupport` 의 사용으로 전역 설정하였습니다(module-api)


## 🔍 관련 이슈
- Close #89 

## 🧪 테스트 결과
> 스샷 때문에 2페이지 1개만 조회
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/3df18dc8-246b-400d-a5f4-2d6a702eeff6" />

## 👀 리뷰어에게 요청사항
- 트러블 슈팅과 관련한 내용을 노션에 적어두었으니 참고해보시면 좋을 것 같습니다.

## 📎 기타 참고 사항
> - 댓글엔티티와 `@OneToMany`가 걸려있는 문제로 인해 고려해야할 점
>   - N+1 해결 하고싶어서 fetch join 쓰면 실제로는 메모리에 모두 로드된 후 리턴되는 현상 발생
>   - `id 페이징 + fetch join쿼리(in절날라감) + 카운트쿼리` 총 3단계로 구분하여 메소드 구현
   
추가로 제가 개인적으로 학습한 내용을 기록해둔 노션 페이지 올려봅니다.(위의 내용을 주제로 썼음)
[JPA Fetch Join과 Paging ](https://nonstop-snapper-a75.notion.site/JPA-Fetch-Join-Paging-1f21f679d4cb80f49a11d9c7c5e7c8e4?pvs=74)
