### PR TITLE
[Fix] 누락된 swagger 응답 및 자잘한 버그 수정 

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/answer/controller/AnswerController.java
+++ b/module-api/src/main/java/com/back2basics/domain/answer/controller/AnswerController.java
@@ -49,7 +49,7 @@ public class AnswerController implements AnswerApiDocs {
         return ApiResponse.success(AnswerResponseCode.ANSWER_UPDATE_SUCCESS);
     }
 
-    @DeleteMapping("/delete/{answerId}")
+    @DeleteMapping("/{answerId}")
     public ResponseEntity<ApiResponse<Void>> deleteAnswer(
         @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @PathVariable Long answerId

--- a/module-api/src/main/java/com/back2basics/domain/answer/swagger/AnswerDocsResult.java
+++ b/module-api/src/main/java/com/back2basics/domain/answer/swagger/AnswerDocsResult.java
@@ -33,21 +33,14 @@ public class AnswerDocsResult {
         {
           "questionId": 1,
           "parentId": null,
-          "authorId": 2,
           "content": "이것은 새로운 답변입니다."
         }
         """;
 
     public static final String ANSWER_UPDATE_REQUEST = """
         {
-          "requesterId": 2,
           "content": "수정된 답변 내용입니다."
         }
         """;
 
-    public static final String ANSWER_DELETE_REQUEST = """
-        {
-          "requesterId": 2
-        }
-        """;
 }

--- a/module-api/src/main/java/com/back2basics/domain/comment/controller/CommentController.java
+++ b/module-api/src/main/java/com/back2basics/domain/comment/controller/CommentController.java
@@ -50,7 +50,7 @@ public class CommentController implements CommentApiDocs {
         return ApiResponse.success(CommentResponseCode.COMMENT_UPDATE_SUCCESS);
     }
 
-    @DeleteMapping("/delete/{commentId}")
+    @DeleteMapping("/{commentId}")
     public ResponseEntity<ApiResponse<Void>> deleteComment(
         @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @PathVariable Long commentId

--- a/module-api/src/main/java/com/back2basics/domain/comment/swagger/CommentDocsResult.java
+++ b/module-api/src/main/java/com/back2basics/domain/comment/swagger/CommentDocsResult.java
@@ -6,7 +6,6 @@ public class CommentDocsResult {
         {
           "postId": 1,
           "parentId": null,
-          "authorId": 1,
           "content": "그거 버그 아니고 기능인데요."
         }
         """;

--- a/module-api/src/main/java/com/back2basics/domain/post/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/post/controller/PostController.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -90,7 +91,7 @@ public class PostController implements PostApiDocs {
         return ApiResponse.success(PostResponseCode.POST_UPDATE_SUCCESS);
     }
 
-    @PutMapping("/delete/{postId}")
+    @DeleteMapping("/{postId}")
     public ResponseEntity<ApiResponse<Void>> deletePost(
         @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @PathVariable Long postId) {

--- a/module-api/src/main/java/com/back2basics/domain/question/dto/response/QuestionResponse.java
+++ b/module-api/src/main/java/com/back2basics/domain/question/dto/response/QuestionResponse.java
@@ -20,6 +20,8 @@ public class QuestionResponse {
     private String content;
     private QuestionStatus status;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
     private List<AnswerResponse> answers;
 
     public static QuestionResponse toResponse(QuestionResult result) {
@@ -34,6 +36,8 @@ public class QuestionResponse {
             .content(result.getContent())
             .status(result.getStatus())
             .createdAt(result.getCreatedAt())
+            .updatedAt(result.getUpdatedAt())
+            .deletedAt(result.getDeletedAt())
             .answers(answerResponses)
             .build();
     }

--- a/module-api/src/main/java/com/back2basics/domain/question/swagger/QuestionDocsResult.java
+++ b/module-api/src/main/java/com/back2basics/domain/question/swagger/QuestionDocsResult.java
@@ -48,7 +48,6 @@ public class QuestionDocsResult {
     public static final String QUESTION_CREATE_REQUEST = """
         {
           "postId": 1,
-          "authorId": 2,
           "content": "이 게시글에 대해 질문이 있습니다."
         }
         """;
@@ -136,7 +135,6 @@ public class QuestionDocsResult {
 
     public static final String QUESTION_UPDATE_REQUEST = """
         {
-          "requesterId": 2,
           "content": "수정된 질문 내용입니다."
         }
         """;
@@ -149,7 +147,7 @@ public class QuestionDocsResult {
           "data": null
         }
         """;
-    
+
     public static final String QUESTION_DELETE_SUCCESS = """
         {
           "success": true,

--- a/module-core/src/main/java/com/back2basics/answer/model/Answer.java
+++ b/module-core/src/main/java/com/back2basics/answer/model/Answer.java
@@ -37,7 +37,6 @@ public class Answer {
 
     public void update(AnswerUpdateCommand command) {
         this.content = command.getContent();
-
     }
 
     public void assignQuestionId(Question question) {

--- a/module-core/src/main/java/com/back2basics/post/model/Post.java
+++ b/module-core/src/main/java/com/back2basics/post/model/Post.java
@@ -60,6 +60,7 @@ public class Post {
 
     public void markDeleted() {
         this.isDelete = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
 

--- a/module-core/src/main/java/com/back2basics/question/model/Question.java
+++ b/module-core/src/main/java/com/back2basics/question/model/Question.java
@@ -41,12 +41,10 @@ public class Question {
 
     public void updateContent(String newContent) {
         this.content = newContent;
-        this.updatedAt = LocalDateTime.now();
     }
 
     public void markAsDeleted() {
         this.isDeleted = true;
-        this.deletedAt = LocalDateTime.now();
     }
 
     public void markAsAnswered() {

--- a/module-core/src/main/java/com/back2basics/question/model/Question.java
+++ b/module-core/src/main/java/com/back2basics/question/model/Question.java
@@ -17,12 +17,15 @@ public class Question {
     private String content;
     private QuestionStatus status;
     private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
     private List<Answer> answers;
     private boolean isDeleted;
 
     @Builder
     public Question(Long id, Long postId, User author, String content, LocalDateTime createdAt,
-        List<Answer> answers,
+        List<Answer> answers, LocalDateTime updatedAt, LocalDateTime deletedAt,
+        QuestionStatus status,
         boolean isDeleted) {
         this.id = id;
         this.postId = postId;
@@ -30,16 +33,20 @@ public class Question {
         this.content = content;
         this.createdAt = createdAt;
         this.status = status != null ? status : QuestionStatus.WAITING;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
         this.answers = answers != null ? new ArrayList<>(answers) : new ArrayList<>();
         this.isDeleted = false;
     }
 
     public void updateContent(String newContent) {
         this.content = newContent;
+        this.updatedAt = LocalDateTime.now();
     }
 
     public void markAsDeleted() {
         this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
     }
 
     public void markAsAnswered() {

--- a/module-core/src/main/java/com/back2basics/question/service/result/QuestionResult.java
+++ b/module-core/src/main/java/com/back2basics/question/service/result/QuestionResult.java
@@ -20,17 +20,22 @@ public class QuestionResult {
     private final String content;
     private final QuestionStatus status;
     private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final LocalDateTime deletedAt;
     private final List<AnswerReadResult> answers;
 
     @Builder
     public QuestionResult(Long id, Long postId, UserInfoResult author, String content,
-        QuestionStatus status, LocalDateTime createdAt, List<AnswerReadResult> answers) {
+        QuestionStatus status, LocalDateTime createdAt, LocalDateTime updatedAt,
+        LocalDateTime deletedAt, List<AnswerReadResult> answers) {
         this.id = id;
         this.postId = postId;
         this.author = author;
         this.content = content;
         this.status = status;
         this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
         this.answers = answers;
     }
 
@@ -46,6 +51,8 @@ public class QuestionResult {
             .content(question.getContent())
             .status(question.getStatus())
             .createdAt(question.getCreatedAt())
+            .updatedAt(question.getUpdatedAt())
+            .deletedAt(question.getDeletedAt())
             .answers(answerResults)
             .build();
     }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/question/QuestionMapper.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/question/QuestionMapper.java
@@ -37,6 +37,9 @@ public class QuestionMapper {
             .postId(entity.getPostId())
             .author(userMapper.toDomain(entity.getAuthor()))
             .createdAt(entity.getCreatedAt())
+            .updatedAt(entity.getUpdatedAt())
+            .deletedAt(entity.getDeletedAt())
+            .status(entity.getStatus())
             .content(entity.getContent())
             .build();
     }
@@ -47,6 +50,9 @@ public class QuestionMapper {
             .postId(entity.getPostId())
             .author(userMapper.toDomain(entity.getAuthor()))
             .createdAt(entity.getCreatedAt())
+            .updatedAt(entity.getUpdatedAt())
+            .deletedAt(entity.getDeletedAt())
+            .status(entity.getStatus())
             .content(entity.getContent())
             .answers(answers)
             .build();


### PR DESCRIPTION
## 📌 개요
- 자잘한 버그 수정 및 누락된 swagger 응답 수정

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [x] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
### Asnwer
POST /api/answers 할때 요청바디에 authorID 삭제
DELETE /api/answers/delete/{id} -> /api/answers/{id} 로 변경

### Comment
POST /api/comments 요청 바디에서 authorID 삭제
PUT 마찬가지, DELETE는 요청 바디 자체를 삭제
DELETE /api/comments/delete/{id} -> /api/comments/{id}로 수정

### Post
게시글 삭제를 DELETE 로 변경, /api/posts/{id} 로 변경

### Question
요청바디에 requesterID 삭제
updatedat, deletedAt 필드 추가
answered, resolved 응답에서 안바뀌는 문제 해결

## 🔍 관련 이슈
- Close #212 

## 🧪 테스트 결과

## 👀 리뷰어에게 요청사항
- swagger에 수정사항 모두 반영되었습니다.

## 📎 기타 참고 사항