### PR TITLE
[Fix] 유저 응답 객체 수정, swagger 응답 수정

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/answer/dto/response/AnswerResponse.java
+++ b/module-api/src/main/java/com/back2basics/domain/answer/dto/response/AnswerResponse.java
@@ -1,9 +1,10 @@
 package com.back2basics.domain.answer.dto.response;
 
 import com.back2basics.answer.service.result.AnswerReadResult;
-import com.back2basics.user.service.result.UserInfoResult;
+import com.back2basics.domain.user.dto.response.UserSummaryResponse;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,22 +15,27 @@ public class AnswerResponse {
     private Long id;
     private Long questionId;
     private Long parentAnswerId;
-    private UserInfoResult author;
+    private UserSummaryResponse author;
     private String content;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-    private List<AnswerReadResult> children;
+    private List<AnswerResponse> children;
 
     public static AnswerResponse toResponse(AnswerReadResult result) {
+
+        List<AnswerResponse> childrenResponses = result.getChildren().stream()
+            .map(AnswerResponse::toResponse)
+            .collect(Collectors.toList());
+
         return AnswerResponse.builder()
             .id(result.getId())
             .questionId(result.getQuestionId())
             .parentAnswerId(result.getParentAnswerId())
-            .author(result.getAuthor())
+            .author(UserSummaryResponse.from(result.getAuthor()))
             .content(result.getContent())
             .createdAt(result.getCreatedAt())
             .updatedAt(result.getUpdatedAt())
-            .children(result.getChildren())
+            .children(childrenResponses)
             .build();
     }
 }

--- a/module-api/src/main/java/com/back2basics/domain/comment/dto/response/CommentResponse.java
+++ b/module-api/src/main/java/com/back2basics/domain/comment/dto/response/CommentResponse.java
@@ -1,7 +1,7 @@
 package com.back2basics.domain.comment.dto.response;
 
 import com.back2basics.comment.service.result.CommentReadResult;
-import com.back2basics.user.service.result.UserInfoResult;
+import com.back2basics.domain.user.dto.response.UserSummaryResponse;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -14,7 +14,7 @@ public class CommentResponse {
     private Long id;
     private Long postId;
     private Long parentCommentId; // 대댓글의 경우 부모 댓글 ID
-    private UserInfoResult author;
+    private UserSummaryResponse author;
     private String content;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -25,7 +25,7 @@ public class CommentResponse {
             .id(result.getId())
             .postId(result.getPostId())
             .parentCommentId(result.getParentCommentId())
-            .author(result.getAuthor())
+            .author(UserSummaryResponse.from(result.getAuthor()))
             .content(result.getContent())
             .createdAt(result.getCreatedAt())
             .updatedAt(result.getUpdatedAt())

--- a/module-api/src/main/java/com/back2basics/domain/comment/swagger/CommentDocsResult.java
+++ b/module-api/src/main/java/com/back2basics/domain/comment/swagger/CommentDocsResult.java
@@ -55,7 +55,10 @@ public class CommentDocsResult {
             {
               "id": 1,
               "postId": 1,
-              "authorId": 1,
+               "author": {
+                 "id": 2,
+                 "username": "johndoe",
+                },
               "content": "그거 버그 아니고 기능인데요.",
               "parentCommentId": null,
               "createdAt": "2024-01-01T10:00:00",

--- a/module-api/src/main/java/com/back2basics/domain/post/dto/response/PostReadResponse.java
+++ b/module-api/src/main/java/com/back2basics/domain/post/dto/response/PostReadResponse.java
@@ -1,11 +1,11 @@
 package com.back2basics.domain.post.dto.response;
 
 import com.back2basics.comment.service.result.CommentReadResult;
+import com.back2basics.domain.user.dto.response.UserSummaryResponse;
 import com.back2basics.post.model.PostStatus;
 import com.back2basics.post.model.PostType;
 import com.back2basics.post.service.result.PostReadResult;
 import com.back2basics.project.service.result.ProjectGetResult;
-import com.back2basics.user.service.result.UserInfoResult;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -16,7 +16,7 @@ import lombok.Getter;
 public class PostReadResponse {
 
     private final Long postId;
-    private final UserInfoResult author;
+    private final UserSummaryResponse author;
     private final String title;
     private final String content;
     private final PostType type;
@@ -33,7 +33,7 @@ public class PostReadResponse {
     public static PostReadResponse toResponse(PostReadResult postDetails) {
         return PostReadResponse.builder()
             .postId(postDetails.getId())
-            .author(postDetails.getAuthor())
+            .author(UserSummaryResponse.from(postDetails.getAuthor()))
             .project(postDetails.getProject())
             .title(postDetails.getTitle())
             .content(postDetails.getContent())

--- a/module-api/src/main/java/com/back2basics/domain/post/swagger/PostDocsResult.java
+++ b/module-api/src/main/java/com/back2basics/domain/post/swagger/PostDocsResult.java
@@ -45,13 +45,6 @@ public class PostDocsResult {
               "id": 1,
               "username": "hongildong",
               "name": "홍길동",
-              "email": "hong@test.com",
-              "phone": "010-1234-5678",
-              "position": "백엔드 개발자",
-              "userType": "MEMBER",
-              "companyId": 1001,
-              "createdAt": "2024-01-01T09:00:00",
-              "updatedAt": "2024-01-01T10:00:00"
             },
             "project": {
               "id": 1,
@@ -102,13 +95,6 @@ public class PostDocsResult {
                   "id": 1,
                   "username": "hongildong",
                   "name": "홍길동",
-                  "email": "hong@test.com",
-                  "phone": "010-1234-5678",
-                  "position": "백엔드 개발자",
-                  "userType": "MEMBER",
-                  "companyId": 1001,
-                  "createdAt": "2024-01-01T09:00:00",
-                  "updatedAt": "2024-01-01T10:00:00"
                 },
                 "project": {
                   "id": 1,

--- a/module-api/src/main/java/com/back2basics/domain/question/dto/response/QuestionResponse.java
+++ b/module-api/src/main/java/com/back2basics/domain/question/dto/response/QuestionResponse.java
@@ -1,7 +1,7 @@
 package com.back2basics.domain.question.dto.response;
 
 import com.back2basics.domain.answer.dto.response.AnswerResponse;
-import com.back2basics.domain.user.dto.response.UserInfoResponse;
+import com.back2basics.domain.user.dto.response.UserSummaryResponse;
 import com.back2basics.question.model.QuestionStatus;
 import com.back2basics.question.service.result.QuestionResult;
 import java.time.LocalDateTime;
@@ -16,7 +16,7 @@ public class QuestionResponse {
 
     private Long id;
     private Long postId;
-    private UserInfoResponse author;
+    private UserSummaryResponse author;
     private String content;
     private QuestionStatus status;
     private LocalDateTime createdAt;
@@ -32,7 +32,7 @@ public class QuestionResponse {
         return QuestionResponse.builder()
             .id(result.getId())
             .postId(result.getPostId())
-            .author(UserInfoResponse.from(result.getAuthor()))
+            .author(UserSummaryResponse.from(result.getAuthor()))
             .content(result.getContent())
             .status(result.getStatus())
             .createdAt(result.getCreatedAt())

--- a/module-api/src/main/java/com/back2basics/domain/question/swagger/QuestionDocsResult.java
+++ b/module-api/src/main/java/com/back2basics/domain/question/swagger/QuestionDocsResult.java
@@ -13,11 +13,6 @@ public class QuestionDocsResult {
             "author": {
               "id": 2,
               "username": "johndoe",
-              "name": "홍길동",
-              "email": "johndoe@example.com",
-              "phone": "010-1234-5678",
-              "position": "백엔드 개발자",
-              "companyId": 1001
             },
             "content": "질문 내용입니다.",
             "status": "WAITING",
@@ -30,11 +25,6 @@ public class QuestionDocsResult {
                 "author": {
                   "id": 3,
                   "username": "janedoe",
-                  "name": "김영희",
-                  "email": "janedoe@example.com",
-                  "phone": "010-5678-1234",
-                  "position": "프론트엔드 개발자",
-                  "companyId": 1002
                 },
                 "content": "답변입니다.",
                 "createdAt": "2024-01-01T11:00:00",
@@ -71,13 +61,13 @@ public class QuestionDocsResult {
               {
                 "id": 1,
                 "postId": 1,
-                "authorId": 2,
-                "content": "질문 내용입니다.",
-                "status": "WAITING",
-                "createdAt": "2024-01-01T10:00:00",
-                "updatedAt": null,
-                "deletedAt": null,
-                "isDeleted": false
+                "author": {
+                  "id": 2,
+                  "username": "johndoe",
+                 },
+                "content": "전체 질문 리스트입니다.",
+                "status": "ANSWERED",
+                "createdAt": "2024-01-01T12:00:00"
               }
             ],
             "pageable": {
@@ -103,12 +93,7 @@ public class QuestionDocsResult {
                 "author": {
                   "id": 2,
                   "username": "johndoe",
-                  "name": "홍길동",
-                  "email": "johndoe@example.com",
-                  "phone": "010-1234-5678",
-                  "position": "백엔드 개발자",
-                  "companyId": 1001
-                },
+                 },
                 "content": "전체 질문 리스트입니다.",
                 "status": "ANSWERED",
                 "createdAt": "2024-01-01T12:00:00"

--- a/module-core/src/main/java/com/back2basics/answer/service/result/AnswerReadResult.java
+++ b/module-core/src/main/java/com/back2basics/answer/service/result/AnswerReadResult.java
@@ -1,7 +1,7 @@
 package com.back2basics.answer.service.result;
 
 import com.back2basics.answer.model.Answer;
-import com.back2basics.user.service.result.UserInfoResult;
+import com.back2basics.user.service.result.UserSummaryResult;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,7 +17,7 @@ public class AnswerReadResult {
     private Long id;
     private Long questionId;
     private Long parentAnswerId;
-    private UserInfoResult author;
+    private UserSummaryResult author;
     private String content;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -28,7 +28,7 @@ public class AnswerReadResult {
             .id(answer.getId())
             .questionId(answer.getQuestionId())
             .parentAnswerId(answer.getParentAnswerId())
-            .author(UserInfoResult.toResult(answer.getAuthor()))
+            .author(UserSummaryResult.from(answer.getAuthor()))
             .content(answer.getContent())
             .createdAt(answer.getCreatedAt())
             .updatedAt(answer.getUpdatedAt())

--- a/module-core/src/main/java/com/back2basics/comment/service/result/CommentReadResult.java
+++ b/module-core/src/main/java/com/back2basics/comment/service/result/CommentReadResult.java
@@ -1,7 +1,7 @@
 package com.back2basics.comment.service.result;
 
 import com.back2basics.comment.model.Comment;
-import com.back2basics.user.service.result.UserInfoResult;
+import com.back2basics.user.service.result.UserSummaryResult;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,7 +17,7 @@ public class CommentReadResult {
     private Long id;
     private Long postId;
     private Long parentCommentId; // 대댓글의 경우 부모 댓글 ID
-    private UserInfoResult author;
+    private UserSummaryResult author;
     private String content;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -28,7 +28,7 @@ public class CommentReadResult {
             .id(comment.getId())
             .postId(comment.getPostId())
             .parentCommentId(comment.getParentCommentId())
-            .author(UserInfoResult.toResult(comment.getAuthor()))
+            .author(UserSummaryResult.from(comment.getAuthor()))
             .content(comment.getContent())
             .createdAt(comment.getCreatedAt())
             .updatedAt(comment.getUpdatedAt())

--- a/module-core/src/main/java/com/back2basics/post/service/result/PostReadResult.java
+++ b/module-core/src/main/java/com/back2basics/post/service/result/PostReadResult.java
@@ -5,7 +5,7 @@ import com.back2basics.post.model.Post;
 import com.back2basics.post.model.PostStatus;
 import com.back2basics.post.model.PostType;
 import com.back2basics.project.service.result.ProjectGetResult;
-import com.back2basics.user.service.result.UserInfoResult;
+import com.back2basics.user.service.result.UserSummaryResult;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -17,7 +17,7 @@ import lombok.Getter;
 public class PostReadResult {
 
     private final Long id;
-    private final UserInfoResult author;
+    private final UserSummaryResult author;
     private final String title;
     private final String content;
     private final PostType type;
@@ -35,7 +35,7 @@ public class PostReadResult {
     public static PostReadResult toResult(Post post) {
         return PostReadResult.builder()
             .id(post.getId())
-            .author(UserInfoResult.toResult(post.getAuthor()))
+            .author(UserSummaryResult.from(post.getAuthor()))
             .project(ProjectGetResult.toResult(post.getProject()))
             .title(post.getTitle())
             .content(post.getContent())

--- a/module-core/src/main/java/com/back2basics/question/service/result/QuestionResult.java
+++ b/module-core/src/main/java/com/back2basics/question/service/result/QuestionResult.java
@@ -4,7 +4,7 @@ package com.back2basics.question.service.result;
 import com.back2basics.answer.service.result.AnswerReadResult;
 import com.back2basics.question.model.Question;
 import com.back2basics.question.model.QuestionStatus;
-import com.back2basics.user.service.result.UserInfoResult;
+import com.back2basics.user.service.result.UserSummaryResult;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,7 +16,7 @@ public class QuestionResult {
 
     private final Long id;
     private final Long postId;
-    private final UserInfoResult author;
+    private final UserSummaryResult author;
     private final String content;
     private final QuestionStatus status;
     private final LocalDateTime createdAt;
@@ -25,7 +25,7 @@ public class QuestionResult {
     private final List<AnswerReadResult> answers;
 
     @Builder
-    public QuestionResult(Long id, Long postId, UserInfoResult author, String content,
+    public QuestionResult(Long id, Long postId, UserSummaryResult author, String content,
         QuestionStatus status, LocalDateTime createdAt, LocalDateTime updatedAt,
         LocalDateTime deletedAt, List<AnswerReadResult> answers) {
         this.id = id;
@@ -47,7 +47,7 @@ public class QuestionResult {
         return QuestionResult.builder()
             .id(question.getId())
             .postId(question.getPostId())
-            .author(UserInfoResult.toResult(question.getAuthor()))
+            .author(UserSummaryResult.from(question.getAuthor()))
             .content(question.getContent())
             .status(question.getStatus())
             .createdAt(question.getCreatedAt())


### PR DESCRIPTION
## 📌 개요
- UserInfoResponse는 너무 많은 정보를 갖고 있으므로 도메인 로직에 필요한 필드만 담은 객체로 응답 객체를 수정

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [x] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
게시글, 댓글, 질문, 응답에서 사용하고 있는 유저 응답객체 변경
swagger ui 수정

## 🔍 관련 이슈
- Close #223 

## 🧪 테스트 결과

## 👀 리뷰어에게 요청사항

## 📎 기타 참고 사항
