### PR TITLE
[Feature] update 로직 수정 및 버그 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,19 +20,11 @@ jobs:
 
       - name: 📝 Create .env file
         run: |
-<<<<<<< HEAD
           echo "${{ secrets.ENV_FILE }}" > .env
 
       - name: 🛠 Build with Gradle
-        run: ./gradlew :module-api:buildNeeded --refresh-dependencies -x test # 이거 진짜 안되는게 맞는지 테스트
-        # run: ./gradlew build -x test
-=======
-          mkdir -p module-api/build/libs                           
-          echo "${{ secrets.ENV_FILE }}" > module-api/build/libs/.env 
-
-      - name: 🛠 Build with Gradle
         run: ./gradlew :module-api:buildNeeded --refresh-dependencies -x test
->>>>>>> develop
+        # run: ./gradlew build -x test
 
       - name: 📤 Upload jar to EC2
         uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           echo "${{ secrets.ENV_FILE }}" > .env
 
       - name: 🛠 Build with Gradle
-        run: ./gradlew :module-api:bootJar -x test
+        run: ./gradlew :module-api:buildNeeded --refresh-dependencies -x test
 
       - name: 📤 Upload jar to EC2
         uses: appleboy/scp-action@v0.1.4
@@ -31,17 +31,8 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: module-api/build/libs/*.jar
+          source: build/libs/*.jar
           target: /home/deploy/app.jar
-
-      - name: 📤 Upload .env to EC2
-        uses: appleboy/scp-action@v0.1.4
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          source: .env
-          target: /home/deploy/
 
       - name: 🚀 Run deploy.sh on EC2
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           echo "${{ secrets.ENV_FILE }}" > .env
 
       - name: 🛠 Build with Gradle
-        run: ./gradlew :module-api:bootJar --no-daemon --refresh-dependencies -x test
+        run: ./gradlew :module-api:bootJar -x test
 
       - name: 📤 Upload jar to EC2
         uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,8 @@ jobs:
           echo "${{ secrets.ENV_FILE }}" > .env
 
       - name: 🛠 Build with Gradle
-        # run: ./gradlew :module-api:buildNeeded --refresh-dependencies -x test
-        run: ./gradlew build -x test
+        run: ./gradlew :module-api:buildNeeded --refresh-dependencies -x test # 이거 진짜 안되는게 맞는지 테스트
+        # run: ./gradlew build -x test
 
       - name: 📤 Upload jar to EC2
         uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,11 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: build/libs/*.jar
-          target: /home/deploy/app.jar
+          # source: build/libs/*.jar
+          # target: /home/deploy/app.jar
+          source: module-api/build/libs/*.jar
+          target: /home/deploy/
+
 
       - name: 🚀 Run deploy.sh on EC2
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,36 +9,45 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: 📦 Checkout source code
-      uses: actions/checkout@v3
+      - name: 📦 Checkout source code
+        uses: actions/checkout@v3
 
-    - name: ☕ Set up Java 17
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '17'
-        
-    - name: 📝 Create .env file
-      run: |
-        echo "${{ secrets.ENV_FILE }}" > .env
-        
-    - name: 🛠 Build with Gradle
-      run: ./gradlew clean build --exclude-task test
+      - name: ☕ Set up Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
-    - name: 📤 Upload jar to EC2
-      uses: appleboy/scp-action@v0.1.4
-      with:
-        host: ${{ secrets.EC2_HOST }}
-        username: ${{ secrets.EC2_USER }}
-        key: ${{ secrets.EC2_SSH_KEY }}
-        source: build/libs/*.jar
-        target: /home/deploy/app.jar
+      - name: 📝 Create .env file
+        run: |
+          echo "${{ secrets.ENV_FILE }}" > .env
 
-    - name: 🚀 Run deploy.sh on EC2
-      uses: appleboy/ssh-action@v1.0.3
-      with:
-        host: ${{ secrets.EC2_HOST }}
-        username: ${{ secrets.EC2_USER }}
-        key: ${{ secrets.EC2_SSH_KEY }}
-        script: |
-          bash /home/deploy/deploy.sh
+      - name: 🛠 Build with Gradle
+        run: ./gradlew clean build --exclude-task test
+
+      - name: 📤 Upload jar to EC2
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: build/libs/*.jar
+          target: /home/deploy/app.jar
+          
+      - name: 📤 Upload .env to EC2
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: .env
+          target: /home/deploy/.env
+
+      - name: 🚀 Run deploy.sh on EC2
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            bash /home/deploy/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           source: build/libs/*.jar
           target: /home/deploy/app.jar
-          
+
       - name: 📤 Upload .env to EC2
         uses: appleboy/scp-action@v0.1.4
         with:
@@ -41,7 +41,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           source: .env
-          target: /home/deploy/.env
+          target: /home/deploy/
 
       - name: 🚀 Run deploy.sh on EC2
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           echo "${{ secrets.ENV_FILE }}" > .env
 
       - name: 🛠 Build with Gradle
-        run: ./gradlew clean build --exclude-task test
+        run: ./gradlew clean :module-api:buildNeeded --refresh-dependencies -x test
 
       - name: 📤 Upload jar to EC2
         uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           echo "${{ secrets.ENV_FILE }}" > .env
 
       - name: 🛠 Build with Gradle
-        run: ./gradlew clean :module-api:buildNeeded --refresh-dependencies -x test
+        run: ./gradlew :module-api:bootJar --no-daemon --refresh-dependencies -x test
 
       - name: 📤 Upload jar to EC2
         uses: appleboy/scp-action@v0.1.4
@@ -31,7 +31,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: build/libs/*.jar
+          source: module-api/build/libs/*.jar
           target: /home/deploy/app.jar
 
       - name: 📤 Upload .env to EC2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,8 @@ jobs:
           echo "${{ secrets.ENV_FILE }}" > .env
 
       - name: 🛠 Build with Gradle
-        run: ./gradlew :module-api:buildNeeded --refresh-dependencies -x test
+        # run: ./gradlew :module-api:buildNeeded --refresh-dependencies -x test
+        run: ./gradlew build -x test
 
       - name: 📤 Upload jar to EC2
         uses: appleboy/scp-action@v0.1.4
@@ -33,8 +34,8 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           # source: build/libs/*.jar
           # target: /home/deploy/app.jar
-          source: module-api/build/libs/*.jar
-          target: /home/deploy/
+          source: module-api/build/libs/module-api-*.jar
+          target: /home/deploy/module-api/build/libs/
 
 
       - name: 🚀 Run deploy.sh on EC2

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '3.3.0'
+    id 'io.spring.dependency-management'
+    id 'java'
 }
 
 dependencies {
@@ -40,6 +42,11 @@ dependencies {
 
 bootJar {
     archiveFileName = "${rootProject.name}.jar"
+    manifest {
+        attributes(
+                'Main-Class': 'com.back2basics.DanmujiApplication'
+        )
+    }
 }
 
 tasks.named('test') {

--- a/module-api/build.gradle
+++ b/module-api/build.gradle
@@ -42,11 +42,6 @@ dependencies {
 
 bootJar {
     archiveFileName = "${rootProject.name}.jar"
-    manifest {
-        attributes(
-                'Main-Class': 'com.back2basics.DanmujiApplication'
-        )
-    }
 }
 
 tasks.named('test') {

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -38,6 +38,11 @@ springdoc:
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
 
+jwt:
+  secret: ${JWT_SECRET}
+  access: ${JWT_ACCESS_EXPIRATION}
+  refresh: ${JWT_REFRESH_EXPIRATION}
+  
 ---
 
 spring:
@@ -66,10 +71,7 @@ spring:
     date-format: yyyy-MM-dd
     serialization:
       write-dates-as-timestamps: false
-jwt:
-  secret: ${JWT_SECRET}
-  access: ${JWT_ACCESS_EXPIRATION}
-  refresh: ${JWT_REFRESH_EXPIRATION}
+
 
 
 #properties

--- a/module-core/src/main/java/com/back2basics/answer/service/AnswerCreateService.java
+++ b/module-core/src/main/java/com/back2basics/answer/service/AnswerCreateService.java
@@ -44,7 +44,7 @@ public class AnswerCreateService implements AnswerCreateUseCase {
 
         Question question = questionValidator.findById(command.getQuestionId());
         question.markAsAnswered();
-        questionUpdatePort.update(question, userIp);
+        questionUpdatePort.update(question);
 
         return answerCreatePort.save(answer);
     }

--- a/module-core/src/main/java/com/back2basics/comment/port/out/CommentUpdatePort.java
+++ b/module-core/src/main/java/com/back2basics/comment/port/out/CommentUpdatePort.java
@@ -4,5 +4,5 @@ import com.back2basics.comment.model.Comment;
 
 public interface CommentUpdatePort {
 
-    void update(Comment comment, String userIp);
+    void update(Comment comment);
 }

--- a/module-core/src/main/java/com/back2basics/comment/service/CommentUpdateService.java
+++ b/module-core/src/main/java/com/back2basics/comment/service/CommentUpdateService.java
@@ -23,6 +23,6 @@ public class CommentUpdateService implements CommentUpdateUseCase {
         commentValidator.isAuthor(comment, userId);
 
         comment.update(command, userIp);
-        commentUpdatePort.update(comment, userIp);
+        commentUpdatePort.update(comment);
     }
 }

--- a/module-core/src/main/java/com/back2basics/post/service/PostCreateService.java
+++ b/module-core/src/main/java/com/back2basics/post/service/PostCreateService.java
@@ -32,10 +32,13 @@ public class PostCreateService implements PostCreateUseCase {
         // todo : 이것도 통일해야할 것 같습니다.
         User user = userQueryPort.findById(userId);
         Project project = projectValidator.findProjectById(command.getProjectId());
-        Long parentPostId = postValidator.findPost(command.getParentId()).getId();
+
+        if (command.getParentId() != null) {
+            postValidator.findPost(command.getParentId()).getId();
+        }
 
         Post post = Post.builder()
-            .parentId(parentPostId)
+            .parentId(command.getParentId())
             .authorIp(userIp)
             .author(user)
             .project(project)

--- a/module-core/src/main/java/com/back2basics/question/port/out/QuestionStatusUpdatePort.java
+++ b/module-core/src/main/java/com/back2basics/question/port/out/QuestionStatusUpdatePort.java
@@ -1,8 +1,10 @@
 package com.back2basics.question.port.out;
 
+import com.back2basics.question.model.Question;
+
 public interface QuestionStatusUpdatePort {
 
-    void markAsAnswered(Long questionId, String userIp);
+    void markAsAnswered(Question question);
 
-    void markAsResolved(Long questionId, String userIp);
+    void markAsResolved(Question question);
 }

--- a/module-core/src/main/java/com/back2basics/question/port/out/QuestionUpdatePort.java
+++ b/module-core/src/main/java/com/back2basics/question/port/out/QuestionUpdatePort.java
@@ -4,5 +4,5 @@ import com.back2basics.question.model.Question;
 
 public interface QuestionUpdatePort {
 
-    void update(Question question, String userIp);
+    void update(Question question);
 }

--- a/module-core/src/main/java/com/back2basics/question/service/QuestionStatusUpdateService.java
+++ b/module-core/src/main/java/com/back2basics/question/service/QuestionStatusUpdateService.java
@@ -18,7 +18,7 @@ public class QuestionStatusUpdateService implements QuestionStatusUpdateUseCase 
     public void markAsAnswered(Long userId, String userIp, Long questionId) {
         Question question = questionValidator.findById(questionId);
         question.markAsAnswered();
-        questionUpdatePort.update(question, userIp);
+        questionUpdatePort.update(question);
     }
 
     @Override
@@ -26,6 +26,6 @@ public class QuestionStatusUpdateService implements QuestionStatusUpdateUseCase 
         Question question = questionValidator.findById(questionId);
         questionValidator.validateAuthor(question, userId);
         question.markAsResolved();
-        questionUpdatePort.update(question, userIp);
+        questionUpdatePort.update(question);
     }
 }

--- a/module-core/src/main/java/com/back2basics/question/service/QuestionUpdateService.java
+++ b/module-core/src/main/java/com/back2basics/question/service/QuestionUpdateService.java
@@ -21,6 +21,6 @@ public class QuestionUpdateService implements QuestionUpdateUseCase {
         questionValidator.validateAuthor(question, userId);
 
         question.updateContent(command.getContent(), userIp);
-        questionUpdatePort.update(question, userIp);
+        questionUpdatePort.update(question);
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/answer/AnswerEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/answer/AnswerEntity.java
@@ -3,7 +3,6 @@ package com.back2basics.adapter.persistence.answer;
 import com.back2basics.adapter.persistence.common.entity.BaseTimeEntity;
 import com.back2basics.adapter.persistence.question.QuestionEntity;
 import com.back2basics.adapter.persistence.user.entity.UserEntity;
-import com.back2basics.answer.model.Answer;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -59,10 +58,5 @@ public class AnswerEntity extends BaseTimeEntity {
 
     public void assignQuestion(QuestionEntity question) {
         this.question = question;
-    }
-
-    public void update(Answer answer) {
-        this.authorIp = answer.getAuthorIp();
-        this.content = answer.getContent();
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/answer/adapter/AnswerUpdateJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/answer/adapter/AnswerUpdateJpaAdapter.java
@@ -1,11 +1,9 @@
 package com.back2basics.adapter.persistence.answer.adapter;
 
-import com.back2basics.adapter.persistence.answer.AnswerEntity;
 import com.back2basics.adapter.persistence.answer.AnswerEntityRepository;
+import com.back2basics.adapter.persistence.answer.AnswerMapper;
 import com.back2basics.answer.model.Answer;
 import com.back2basics.answer.port.out.AnswerUpdatePort;
-import com.back2basics.infra.exception.answer.AnswerErrorCode;
-import com.back2basics.infra.exception.answer.AnswerException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,14 +11,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class AnswerUpdateJpaAdapter implements AnswerUpdatePort {
 
+    private final AnswerMapper mapper;
     private final AnswerEntityRepository answerRepository;
 
     @Override
     public void update(Answer answer) {
-        AnswerEntity entity = answerRepository.findById(answer.getId())
-            .orElseThrow(() -> new AnswerException(AnswerErrorCode.ANSWER_NOT_FOUND));
-
-        entity.update(answer);
-        answerRepository.save(entity);
+        answerRepository.save(mapper.toEntity(answer));
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/comment/CommentEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/comment/CommentEntity.java
@@ -59,9 +59,4 @@ public class CommentEntity extends BaseTimeEntity {
     public void assignPost(PostEntity post) {
         this.post = post;
     }
-
-    public void updateContent(String content, String userIp) {
-        this.authorIp = userIp;
-        this.content = content;
-    }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/comment/adapter/CommentUpdateJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/comment/adapter/CommentUpdateJpaAdapter.java
@@ -1,11 +1,9 @@
 package com.back2basics.adapter.persistence.comment.adapter;
 
-import com.back2basics.adapter.persistence.comment.CommentEntity;
 import com.back2basics.adapter.persistence.comment.CommentEntityRepository;
+import com.back2basics.adapter.persistence.comment.CommentMapper;
 import com.back2basics.comment.model.Comment;
 import com.back2basics.comment.port.out.CommentUpdatePort;
-import com.back2basics.infra.exception.comment.CommentErrorCode;
-import com.back2basics.infra.exception.comment.CommentException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -13,17 +11,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CommentUpdateJpaAdapter implements CommentUpdatePort {
 
+    private final CommentMapper mapper;
     private final CommentEntityRepository commentRepository;
 
     @Override
-    public void update(Comment comment, String userIp) {
-        // CommentEntity entity = mapper.toEntity(comment);
-
-        CommentEntity entity = commentRepository.findById(comment.getId())
-            .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
-
-        entity.updateContent(comment.getContent(), userIp);
-
-        commentRepository.save(entity);
+    public void update(Comment comment) {
+        commentRepository.save(mapper.toEntity(comment));
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/post/PostEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/post/PostEntity.java
@@ -84,19 +84,5 @@ public class PostEntity extends BaseTimeEntity {
         this.project = project;
         this.completedAt = completedAt;
     }
-
-    public void update(String title, String authorIp, String content, PostType type,
-        PostStatus status,
-        int priority, LocalDateTime completedAt, boolean isDelete) {
-        this.authorIp = authorIp;
-        this.title = title;
-        this.content = content;
-        this.type = type;
-        this.status = status;
-        this.priority = priority;
-        this.completedAt = completedAt;
-        if (isDelete) {
-            this.markDeleted();
-        }
-    }
+    
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/post/PostMapper.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/post/PostMapper.java
@@ -56,17 +56,5 @@ public class PostMapper {
 
         return entity;
     }
-
-    public void updateEntityFields(PostEntity entity, Post domain) {
-        entity.update(
-            domain.getAuthorIp(),
-            domain.getTitle(),
-            domain.getContent(),
-            domain.getType(),
-            domain.getStatus(),
-            domain.getPriority(),
-            domain.getCompletedAt(),
-            domain.isDelete()
-        );
-    }
+    
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/post/adapter/PostUpdateJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/post/adapter/PostUpdateJpaAdapter.java
@@ -1,10 +1,7 @@
 package com.back2basics.adapter.persistence.post.adapter;
 
-import com.back2basics.adapter.persistence.post.PostEntity;
 import com.back2basics.adapter.persistence.post.PostEntityRepository;
 import com.back2basics.adapter.persistence.post.PostMapper;
-import com.back2basics.infra.exception.post.PostErrorCode;
-import com.back2basics.infra.exception.post.PostException;
 import com.back2basics.post.model.Post;
 import com.back2basics.post.port.out.PostUpdatePort;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +16,6 @@ public class PostUpdateJpaAdapter implements PostUpdatePort {
 
     @Override
     public void update(Post post) {
-        PostEntity entity = postRepository.findById(post.getId())
-            .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
-
-        mapper.updateEntityFields(entity, post);
-        postRepository.save(entity);
+        postRepository.save(mapper.toEntity(post));
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/question/QuestionEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/question/QuestionEntity.java
@@ -2,7 +2,6 @@ package com.back2basics.adapter.persistence.question;
 
 import com.back2basics.adapter.persistence.common.entity.BaseTimeEntity;
 import com.back2basics.adapter.persistence.user.entity.UserEntity;
-import com.back2basics.question.model.Question;
 import com.back2basics.question.model.QuestionStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -56,16 +55,4 @@ public class QuestionEntity extends BaseTimeEntity {
         this.content = content;
         this.status = status;
     }
-
-    public void update(Question question, String userIp) {
-        this.authorIp = userIp;
-        this.content = question.getContent();
-        this.status = question.getStatus();
-    }
-
-    public void updateStatus(QuestionStatus status, String userIp) {
-        this.status = status;
-        this.authorIp = userIp;
-    }
-
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/question/adapter/QuestionStatusUpdateJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/question/adapter/QuestionStatusUpdateJpaAdapter.java
@@ -1,37 +1,30 @@
 package com.back2basics.adapter.persistence.question.adapter;
 
 
-import com.back2basics.adapter.persistence.question.QuestionEntity;
 import com.back2basics.adapter.persistence.question.QuestionEntityRepository;
-import com.back2basics.infra.exception.question.QuestionErrorCode;
-import com.back2basics.infra.exception.question.QuestionException;
-import com.back2basics.question.model.QuestionStatus;
+import com.back2basics.adapter.persistence.question.QuestionMapper;
+import com.back2basics.question.model.Question;
 import com.back2basics.question.port.out.QuestionStatusUpdatePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+// todo : 얘도 그냥 업데이트 요청 하나로 묶을 수 있을지 고민
 public class QuestionStatusUpdateJpaAdapter implements QuestionStatusUpdatePort {
 
+    private final QuestionMapper mapper;
     private final QuestionEntityRepository questionRepository;
 
-    @Override
-    public void markAsAnswered(Long questionId, String userIp) {
-        QuestionEntity entity = questionRepository.findById(questionId)
-            .orElseThrow(() -> new QuestionException(QuestionErrorCode.QUESTION_NOT_FOUND));
 
-        entity.updateStatus(QuestionStatus.ANSWERED, userIp);
-        questionRepository.save(entity);
+    @Override
+    public void markAsAnswered(Question question) {
+        questionRepository.save(mapper.toEntity(question));
     }
 
     @Override
-    public void markAsResolved(Long questionId, String userIp) {
-        QuestionEntity entity = questionRepository.findById(questionId)
-            .orElseThrow(() -> new QuestionException(QuestionErrorCode.QUESTION_NOT_FOUND));
-
-        entity.updateStatus(QuestionStatus.RESOLVED, userIp);
-        questionRepository.save(entity);
+    public void markAsResolved(Question question) {
+        questionRepository.save(mapper.toEntity(question));
     }
 }
 

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/question/adapter/QuestionUpdateJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/question/adapter/QuestionUpdateJpaAdapter.java
@@ -1,9 +1,7 @@
 package com.back2basics.adapter.persistence.question.adapter;
 
-import com.back2basics.adapter.persistence.question.QuestionEntity;
 import com.back2basics.adapter.persistence.question.QuestionEntityRepository;
-import com.back2basics.infra.exception.question.QuestionErrorCode;
-import com.back2basics.infra.exception.question.QuestionException;
+import com.back2basics.adapter.persistence.question.QuestionMapper;
 import com.back2basics.question.model.Question;
 import com.back2basics.question.port.out.QuestionUpdatePort;
 import lombok.RequiredArgsConstructor;
@@ -13,14 +11,11 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class QuestionUpdateJpaAdapter implements QuestionUpdatePort {
 
+    private final QuestionMapper mapper;
     private final QuestionEntityRepository questionRepository;
 
     @Override
-    public void update(Question question, String userIp) {
-        QuestionEntity entity = questionRepository.findById(question.getId())
-            .orElseThrow(() -> new QuestionException(QuestionErrorCode.QUESTION_NOT_FOUND));
-
-        entity.update(question, userIp);
-        questionRepository.save(entity);
+    public void update(Question question) {
+        questionRepository.save(mapper.toEntity(question));
     }
 }


### PR DESCRIPTION
## 📌 개요
- 영속성 계층에서 update 메소드를 삭제 (불필요)
- 업데이트 내용을 반영한 도메인 객체를 사용하도록 수정

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [x] 기타 (Other)

## ✅ 작업 내용 상세
- (공용)수정된 도메인 객체를 넘기고 -> 넘겨받은 도메인 객체를 mapper를 통해 entity로 변환 후 save 하도록 수정
- 게시글,댓글,질문,답변 업데이트 로직 수정
- 게시글 생성 시 부모 게시글이 없으면 생성이 안되던 문제 해결
- mapper 클래스에 updateField라는 메소드로 entity 필드에 직접 접근하는 메소드 삭제
- entity에서 update메소드로 필드에 직접 접근하는 메소드 삭제


## 🔍 관련 이슈
- Close #256 


## 🧪 테스트 결과
- insomnia 에서 수정 후 정상적인 응답 확인
- mysql에서 수정 값 table 적용 확인

## 👀 리뷰어에게 요청사항


## 📎 기타 참고 사항

