### PR TITLE
[Feature] ip 값이 제대로 삽입되도록 수정

### DIFF
--- a/module-api/src/main/java/com/back2basics/global/utils/ClientUtils.java
+++ b/module-api/src/main/java/com/back2basics/global/utils/ClientUtils.java
@@ -1,25 +1,33 @@
 package com.back2basics.global.utils;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class ClientUtils {
 
     public static String getRemoteIp(HttpServletRequest request) {
         String ip = request.getHeader("x-forwarded-for");
+        log.debug("[ClientUtils] X-Forwarded-For: {}", ip);
 
         // proxy 환경일 경우
         if (ip == null || ip.length() == 0) {
             ip = request.getHeader("Proxy-Client-IP");
+            log.debug("[ClientUtils] Proxy-Client-IP: {}", ip);
+
         }
 
         // 웹로직 서버일 경우(WAS)
         if (ip == null || ip.length() == 0) {
             ip = request.getHeader("WL-Proxy-Client-IP");
+            log.debug("[ClientUtils] WL-Proxy-Client-IP: {}", ip);
+
         }
 
         // 그 외
         if (ip == null || ip.length() == 0) {
             ip = request.getRemoteAddr();
+            log.debug("[ClientUtils] 다중 IP 분리 후 사용: {}", ip);
         }
 
         // 여러 ip가 있으면 첫 번째 꺼만 사용
@@ -30,8 +38,10 @@ public class ClientUtils {
         // IPv6 형식 중 IPv4-mapped address (::ffff:192.0.2.128) 제거
         if (ip != null && ip.startsWith("::ffff:")) {
             ip = ip.substring(7);
+            log.debug("[ClientUtils] IPv4-mapped IPv6 변환: {}", ip);
         }
 
+        log.debug("[ClientUtils] 최종 반환 IP: {}", ip);
         return ip;
     }
 }

--- a/module-api/src/main/java/com/back2basics/global/utils/ClientUtils.java
+++ b/module-api/src/main/java/com/back2basics/global/utils/ClientUtils.java
@@ -27,6 +27,11 @@ public class ClientUtils {
             ip = ip.split(",")[0].trim();
         }
 
+        // IPv6 형식 중 IPv4-mapped address (::ffff:192.0.2.128) 제거
+        if (ip != null && ip.startsWith("::ffff:")) {
+            ip = ip.substring(7);
+        }
+
         return ip;
     }
 }

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -43,6 +43,8 @@ jwt:
   access: ${JWT_ACCESS_EXPIRATION}
   refresh: ${JWT_REFRESH_EXPIRATION}
 
+server:
+  forward-headers-strategy: native
 ---
 
 spring:


### PR DESCRIPTION
## 📌 개요
- 네트워크 환경에 따라 IPv4 또는 IPv6 로 authorIP가 응답되는 것을 확인, 수정
- (정확히는 잘 모르겠으나 핫스팟으로 잡았을떄랑 공용wifi로 잡았을때랑 달랐음)

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- ip를 받아올때 debug 레벨로 로그 출력 추가
- IPv6 형식일 경우 IPv4 형식으로 변환하는 로직 추가
- spring boot로 띄운 was가 nginx 리버스 프록시 환경에서 클라이언트의 실제 IP를 정확히 추출할 수 있도록 `application.yml`에 옵션 추가
   - `server.forward-headers-strategy: native`
- 인스턴스 내의 nginx config에서  X-Forwarded-For  헤더로 전달되는 클라이언트 ip 값을 was가 인식할 수 있도록 설정을 추가 
```shell
location / {
    proxy_pass http://localhost:8080;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # 추가
}
```
   

## 🔍 관련 이슈
- Close #259 

## 🧪 테스트 결과

## 👀 리뷰어에게 요청사항

## 📎 기타 참고 사항

