### PR TITLE
[Feature] 회사 softDelete시 해당 회사 속한 회원 company_id Null로 지정

### DIFF
--- a/module-core/src/main/java/com/back2basics/company/service/DeleteCompanyService.java
+++ b/module-core/src/main/java/com/back2basics/company/service/DeleteCompanyService.java
@@ -4,6 +4,9 @@ import com.back2basics.company.model.Company;
 import com.back2basics.company.port.in.DeleteCompanyUseCase;
 import com.back2basics.company.port.out.DeleteCompanyPort;
 import com.back2basics.infra.validation.validator.CompanyValidator;
+import com.back2basics.user.model.User;
+import com.back2basics.user.port.out.UserQueryPort;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,11 +16,16 @@ public class DeleteCompanyService implements DeleteCompanyUseCase {
 
     private final DeleteCompanyPort deleteCompanyPort;
     private final CompanyValidator companyValidator;
+    private final UserQueryPort userQueryPort;
 
 
     @Override
     public void deleteCompany(Long id) {
         Company company = companyValidator.findCompany(id);
+
+        List<User> users = userQueryPort.findAllByCompanyIdAndDeletedAtIsNull(id);
+        users.forEach(User::unlinkCompany);
+        userQueryPort.saveAll(users);
 
         company.markDeleted();
 

--- a/module-core/src/main/java/com/back2basics/user/model/User.java
+++ b/module-core/src/main/java/com/back2basics/user/model/User.java
@@ -82,4 +82,8 @@ public class User {
     public void updateLastLoginAt() {
         this.lastLoginAt = LocalDateTime.now();
     }
+
+    public void unlinkCompany() {
+        this.companyId = null;
+    }
 }

--- a/module-core/src/main/java/com/back2basics/user/port/out/UserQueryPort.java
+++ b/module-core/src/main/java/com/back2basics/user/port/out/UserQueryPort.java
@@ -21,5 +21,9 @@ public interface UserQueryPort {
 
     List<User> findAllByCompanyId(Long companyId);
 
+    List<User> findAllByCompanyIdAndDeletedAtIsNull(Long companyId);
+
     boolean existsById(Long userId);
+
+    void saveAll(List<User> users);
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/user/adapter/out/UserQueryAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/user/adapter/out/UserQueryAdapter.java
@@ -2,12 +2,14 @@ package com.back2basics.adapter.persistence.user.adapter.out;
 
 import static com.back2basics.infra.exception.user.UserErrorCode.USER_NOT_FOUND;
 
+import com.back2basics.adapter.persistence.user.entity.UserEntity;
 import com.back2basics.adapter.persistence.user.mapper.UserMapper;
 import com.back2basics.adapter.persistence.user.repository.UserEntityRepository;
 import com.back2basics.infra.exception.user.UserException;
 import com.back2basics.user.model.User;
 import com.back2basics.user.port.out.UserQueryPort;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -61,8 +63,23 @@ public class UserQueryAdapter implements UserQueryPort {
     }
 
     @Override
+    public List<User> findAllByCompanyIdAndDeletedAtIsNull(Long companyId) {
+        return userEntityRepository.findAllByCompany_IdAndDeletedAtIsNull(companyId)
+            .stream().map(userMapper::toDomain).toList();
+    }
+
+    @Override
     public boolean existsById(Long userId) {
         return userEntityRepository.existsById(userId);
+    }
+
+    @Override
+    public void saveAll(List<User> users) {
+        List<UserEntity> userEntities = users.stream()
+            .map(userMapper::toEntity)  // User → UserEntity 매핑
+            .collect(Collectors.toList());
+
+        userEntityRepository.saveAll(userEntities);
     }
 
 }


### PR DESCRIPTION
## 📌 개요
회사 softDelete시 해당 회사 속한 회원 company_id Null로 지정

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [X] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
회사 softDelete시 해당 회사 속한 회원 company_id Null로 지정
User 클래스에 메서드 추가하여 comapny_id를 null로 만든 뒤 저장

## 🔍 관련 이슈
- Close #329

## 🧪 테스트 결과
정상적으로 회사 삭제하고 유저는 소속이 N/A로 표시

## 👀 리뷰어에게 요청사항


## 📎 기타 참고 사항

