### PR TITLE
[Feature] 회사 수정 시 중복확인 기능 구현 및 유효성검사 추가

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/company/dto/request/CreateCompanyRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/company/dto/request/CreateCompanyRequest.java
@@ -2,6 +2,8 @@ package com.back2basics.domain.company.dto.request;
 
 import com.back2basics.company.port.in.command.CreateCompanyCommand;
 import com.back2basics.infra.validation.custom.CustomNotBlank;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
@@ -13,12 +15,18 @@ public class CreateCompanyRequest {
     private String ceoName;
     @CustomNotBlank(message = "회사 소개는 공백일 수 없습니다.")
     private String bio;
-    private Long bizNo;
+    @Pattern(regexp = "\\d{10}", message = "사업자등록번호는 숫자 10자리여야 합니다.")
+    private String bizNo;
     @CustomNotBlank(message = "회사 주소는 공백일 수 없습니다.")
     private String address;
     @CustomNotBlank(message = "회사 이메일 주소는 공백일 수 없습니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
     @CustomNotBlank(message = "회사 전화번호는 공백일 수 없습니다.")
+    @Pattern(
+        regexp = "^(\\d{2,3})-(\\d{3,4})-(\\d{4})$",
+        message = "전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678"
+    )
     private String tel;
 
     public CreateCompanyCommand toCommand() {
@@ -26,7 +34,7 @@ public class CreateCompanyRequest {
             .name(name)
             .ceoName(ceoName)
             .bio(bio)
-            .bizNo(bizNo)
+            .bizNo(Long.parseLong(bizNo))
             .address(address)
             .email(email)
             .tel(tel)

--- a/module-api/src/main/java/com/back2basics/domain/company/dto/request/UpdateCompanyRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/company/dto/request/UpdateCompanyRequest.java
@@ -2,6 +2,8 @@ package com.back2basics.domain.company.dto.request;
 
 import com.back2basics.company.port.in.command.UpdateCompanyCommand;
 import com.back2basics.infra.validation.custom.CustomNotBlank;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
@@ -13,12 +15,18 @@ public class UpdateCompanyRequest {
     private String ceoName;
     @CustomNotBlank(message = "회사 소개는 공백일 수 없습니다.")
     private String bio;
-    private Long bizNo;
+    @Pattern(regexp = "\\d{10}", message = "사업자등록번호는 숫자 10자리여야 합니다.")
+    private String bizNo;
     @CustomNotBlank(message = "회사 주소는 공백일 수 없습니다.")
     private String address;
     @CustomNotBlank(message = "회사 이메일 주소는 공백일 수 없습니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
     @CustomNotBlank(message = "회사 전화번호는 공백일 수 없습니다.")
+    @Pattern(
+        regexp = "^(\\d{2,3})-(\\d{3,4})-(\\d{4})$",
+        message = "전화번호 형식이 올바르지 않습니다. 예: 010-1234-5678"
+    )
     private String tel;
 
     public UpdateCompanyCommand toCommand() {
@@ -26,7 +34,7 @@ public class UpdateCompanyRequest {
             .name(name)
             .ceoName(ceoName)
             .bio(bio)
-            .bizNo(bizNo)
+            .bizNo(Long.parseLong(bizNo))
             .address(address)
             .email(email)
             .tel(tel)

--- a/module-core/src/main/java/com/back2basics/company/port/out/UpdateCompanyPort.java
+++ b/module-core/src/main/java/com/back2basics/company/port/out/UpdateCompanyPort.java
@@ -6,4 +6,9 @@ public interface UpdateCompanyPort {
 
     void update(Company company);
 
+    boolean existsByNameAndIdNot(String name, Long id);
+
+    boolean existsByBizNoAndIdNot(Long bizNo, Long id);
+
+    boolean existsByAddressAndIdNot(String address, Long id);
 }

--- a/module-core/src/main/java/com/back2basics/company/service/UpdateCompanyService.java
+++ b/module-core/src/main/java/com/back2basics/company/service/UpdateCompanyService.java
@@ -17,6 +17,8 @@ public class UpdateCompanyService implements UpdateCompanyUseCase {
 
     @Override
     public void updateCompany(Long id, UpdateCompanyCommand command) {
+        companyValidator.validateDuplicate(command, id);
+
         Company company = companyValidator.findCompany(id);
 
         company.update(command);

--- a/module-core/src/main/java/com/back2basics/infra/validation/validator/CompanyValidator.java
+++ b/module-core/src/main/java/com/back2basics/infra/validation/validator/CompanyValidator.java
@@ -2,8 +2,10 @@ package com.back2basics.infra.validation.validator;
 
 import com.back2basics.company.model.Company;
 import com.back2basics.company.port.in.command.CreateCompanyCommand;
+import com.back2basics.company.port.in.command.UpdateCompanyCommand;
 import com.back2basics.company.port.out.CreateCompanyPort;
 import com.back2basics.company.port.out.ReadCompanyPort;
+import com.back2basics.company.port.out.UpdateCompanyPort;
 import com.back2basics.global.response.error.ErrorResponse.FieldError;
 import com.back2basics.infra.exception.company.CompanyErrorCode;
 import com.back2basics.infra.exception.company.CompanyException;
@@ -19,6 +21,7 @@ public class CompanyValidator {
 
     private final ReadCompanyPort readCompanyPort;
     private final CreateCompanyPort createCompanyPort;
+    private final UpdateCompanyPort updateCompanyPort;
 
     public Company findCompany(Long id) {
         return readCompanyPort.findById(id)
@@ -43,6 +46,26 @@ public class CompanyValidator {
                     "이미 존재하는 사업자등록번호입니다"));
         }
         if (createCompanyPort.existsByAddress(command.getAddress())) {
+            errors.add(new FieldError("address", command.getAddress(), "이미 존재하는 주소입니다"));
+        }
+
+        if (!errors.isEmpty()) {
+            throw new DuplicateCompanyException(errors);
+        }
+    }
+
+    public void validateDuplicate(UpdateCompanyCommand command, Long id) {
+        List<FieldError> errors = new ArrayList<>();
+
+        if (updateCompanyPort.existsByNameAndIdNot(command.getName(), id)) {
+            errors.add(new FieldError("name", command.getName(), "이미 존재하는 회사명입니다"));
+        }
+        if (updateCompanyPort.existsByBizNoAndIdNot(command.getBizNo(), id)) {
+            errors.add(
+                new FieldError("bizNo", command.getBizNo().toString(),
+                    "이미 존재하는 사업자등록번호입니다"));
+        }
+        if (updateCompanyPort.existsByAddressAndIdNot(command.getAddress(), id)) {
             errors.add(new FieldError("address", command.getAddress(), "이미 존재하는 주소입니다"));
         }
 

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/company/CompanyEntityRepository.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/company/CompanyEntityRepository.java
@@ -26,4 +26,10 @@ public interface CompanyEntityRepository extends JpaRepository<CompanyEntity, Lo
     boolean existsByAddress(String addr);
 
     List<CompanyEntity> findTop5ByDeletedAtIsNullOrderByCreatedAtDesc();
+
+    boolean existsByNameAndIdNot(String name, Long id);
+
+    boolean existsByBizNoAndIdNot(Long bizNo, Long id);
+
+    boolean existsByAddressAndIdNot(String address, Long id);
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/company/adapter/UpdateCompanyJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/company/adapter/UpdateCompanyJpaAdapter.java
@@ -19,4 +19,19 @@ public class UpdateCompanyJpaAdapter implements UpdateCompanyPort {
         companyEntityRepository.save(companyMapper.toEntity(company));
     }
 
+    @Override
+    public boolean existsByNameAndIdNot(String name, Long id) {
+        return companyEntityRepository.existsByNameAndIdNot(name, id);
+    }
+
+    @Override
+    public boolean existsByBizNoAndIdNot(Long bizNo, Long id) {
+        return companyEntityRepository.existsByBizNoAndIdNot(bizNo, id);
+    }
+
+    @Override
+    public boolean existsByAddressAndIdNot(String address, Long id) {
+        return companyEntityRepository.existsByAddressAndIdNot(address, id);
+    }
+
 }


### PR DESCRIPTION
## 📌 개요
생성과 달리 수정 시 중복확인 기능에는 본인을 제외한 중복검사가 필요함.
그렇지 않으면 기존에 저장되어있는 본인까지 중복검사를 진행하므로 예외를 발생시키게 됌.

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [X] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
생성과 달리 수정 시 중복확인 기능에는 본인을 제외한 중복검사가 필요함.
그렇지 않으면 기존에 저장되어있는 본인까지 중복검사를 진행하므로 예외를 발생시키게 됌.

## 🔍 관련 이슈
- Close #362 

## 🧪 테스트 결과
로컬환경 테스트 진행

