### PR TITLE
[Feature] 승인 요청, 관리자 문의/답변, 체크리스트 도메인에 이력 로그 기능 추가 및 관련 오류 수정

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/inquiry/controller/InquiryController.java
+++ b/module-api/src/main/java/com/back2basics/domain/inquiry/controller/InquiryController.java
@@ -105,6 +105,10 @@ public class InquiryController {
         return ApiResponse.success(INQUIRY_READ_ALL_SUCCESS, responseList);
     }
 
+    // todo:  의견
+    // swlee: 사실 여기서 권한체크를 하면 편하긴 한데 서비스레이어에서 validator 통해서 검증로직을 처리하므로
+    // validator에게 권한 검증 로직을 위임하는 것이 나아보입니다.
+    // byuser 메소드는 시큐리티객체 사용해야되고 byadmin은 사용안해도 되는 것도 비일관적입니다.(byadmin은 이력생성때문에 제가 넣었어요)
     @PutMapping("/{inquiryId}/user")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<ApiResponse<Void>> updateByUser(
@@ -119,10 +123,12 @@ public class InquiryController {
     @PutMapping("/{inquiryId}/admin")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<Void>> updateByAdmin(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @PathVariable Long inquiryId,
         @RequestBody UpdateInquiryStatusByAdminRequest request
     ) {
-        updateInquiryUseCase.updateByAdmin(inquiryId, request.toCommand());
+        updateInquiryUseCase.updateByAdmin(inquiryId, request.toCommand(),
+            customUserDetails.getId());
         return ApiResponse.success(INQUIRY_UPDATE_SUCCESS);
     }
 

--- a/module-api/src/main/java/com/back2basics/domain/todolist/controller/TodoListController.java
+++ b/module-api/src/main/java/com/back2basics/domain/todolist/controller/TodoListController.java
@@ -46,21 +46,27 @@ public class TodoListController {
     }
 
     @PutMapping("/{todoListId}")
-    public ResponseEntity<ApiResponse<Void>> update(@PathVariable Long todoListId,
+    public ResponseEntity<ApiResponse<Void>> update(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable Long todoListId,
         @RequestBody CreateTodoListRequest request) {
-        updateTodoListUseCase.update(todoListId, request.toCommand());
+        updateTodoListUseCase.update(todoListId, request.toCommand(), userDetails.getId());
         return ApiResponse.success(TODO_LIST_UPDATE_SUCCESS);
     }
 
     @PutMapping("/{todoListId}/check")
-    public ResponseEntity<ApiResponse<Void>> check(@PathVariable Long todoListId) {
-        updateTodoListUseCase.check(todoListId);
+    public ResponseEntity<ApiResponse<Void>> check(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable Long todoListId) {
+        updateTodoListUseCase.check(todoListId, userDetails.getId());
         return ApiResponse.success(TODO_LIST_UPDATE_SUCCESS);
     }
 
     @DeleteMapping("/{todoListId}")
-    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long todoListId) {
-        deleteTodoListUseCase.delete(todoListId);
+    public ResponseEntity<ApiResponse<Void>> delete(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable Long todoListId) {
+        deleteTodoListUseCase.delete(todoListId, userDetails.getId());
         return ApiResponse.success(TODO_LIST_DELETE_SUCCESS);
     }
 

--- a/module-core/src/main/java/com/back2basics/approval/model/ApprovalRequest.java
+++ b/module-core/src/main/java/com/back2basics/approval/model/ApprovalRequest.java
@@ -1,12 +1,13 @@
 package com.back2basics.approval.model;
 
+import com.back2basics.history.strategy.TargetDomain;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
-public class ApprovalRequest {
+public class ApprovalRequest implements TargetDomain {
 
     private final Long id;
 
@@ -54,5 +55,22 @@ public class ApprovalRequest {
         if (!this.responseIds.contains(approverId)) {
             this.responseIds.add(approverId);
         }
+    }
+
+    @Override
+    public Long getId() {
+        return this.id;
+    }
+
+    public static ApprovalRequest copyOf(ApprovalRequest original) {
+        return new ApprovalRequest(
+            original.id,
+            original.projectStepId,
+            original.requesterId,
+            original.approvalRequestStatus,
+            original.requestedAt,
+            original.completedAt,
+            new ArrayList<>(original.responseIds)
+        );
     }
 }

--- a/module-core/src/main/java/com/back2basics/approval/port/out/ApprovalRequestCommandPort.java
+++ b/module-core/src/main/java/com/back2basics/approval/port/out/ApprovalRequestCommandPort.java
@@ -4,7 +4,7 @@ import com.back2basics.approval.model.ApprovalRequest;
 
 public interface ApprovalRequestCommandPort {
 
-    Long create(ApprovalRequest approvalRequest);
+    ApprovalRequest create(ApprovalRequest approvalRequest);
 
     void update(ApprovalRequest approvalRequest);
 

--- a/module-core/src/main/java/com/back2basics/approval/service/CreateApprovalRequestRequestService.java
+++ b/module-core/src/main/java/com/back2basics/approval/service/CreateApprovalRequestRequestService.java
@@ -4,6 +4,8 @@ import com.back2basics.approval.model.ApprovalRequest;
 import com.back2basics.approval.port.in.CreateApprovalRequestUseCase;
 import com.back2basics.approval.port.in.command.CreateApprovalCommand;
 import com.back2basics.approval.port.out.ApprovalRequestCommandPort;
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
 import com.back2basics.infra.validation.validator.ProjectStepValidator;
 import com.back2basics.infra.validation.validator.UserValidator;
 import com.back2basics.notify.model.NotificationType;
@@ -13,13 +15,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor
+@RequiredArgsConstructor // Request 두번 써있는거 오타인가요?
 public class CreateApprovalRequestRequestService implements CreateApprovalRequestUseCase {
 
     private final UserValidator userValidator; // validation 처리는 service에서 처리해야 함
     private final ProjectStepValidator projectStepValidator;
     private final ApprovalRequestCommandPort approvalRequestCommandPort;
     private final NotifyUseCase notifyUseCase;
+    private final HistoryLogService historyLogService;
 
     @Override
     public void create(Long stepId, Long requesterId, CreateApprovalCommand command) {
@@ -29,16 +32,19 @@ public class CreateApprovalRequestRequestService implements CreateApprovalReques
 
         ApprovalRequest approvalRequest = ApprovalRequest.create(stepId, requesterId,
             command.responseIds());
-        Long savedId = approvalRequestCommandPort.create(approvalRequest);
+        ApprovalRequest savedApprovalRequest = approvalRequestCommandPort.create(approvalRequest);
 
         for (Long clientId : command.responseIds()) {
             SendNotificationCommand notifyCommand = new SendNotificationCommand(
                 clientId,
-                savedId,
+                savedApprovalRequest.getId(),
                 NotificationType.STEP_APPROVAL_REQUEST.getDescription(),
                 NotificationType.STEP_APPROVAL_REQUEST
             );
             notifyUseCase.notify(notifyCommand);
         }
+
+        historyLogService.logCreated(DomainType.APPROVAL_REQUEST, requesterId, savedApprovalRequest,
+            "승인 요청 생성");
     }
 }

--- a/module-core/src/main/java/com/back2basics/approval/service/CreateApprovalRequestService.java
+++ b/module-core/src/main/java/com/back2basics/approval/service/CreateApprovalRequestService.java
@@ -15,8 +15,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
-@RequiredArgsConstructor // Request 두번 써있는거 오타인가요?
-public class CreateApprovalRequestRequestService implements CreateApprovalRequestUseCase {
+@RequiredArgsConstructor
+public class CreateApprovalRequestService implements CreateApprovalRequestUseCase {
 
     private final UserValidator userValidator; // validation 처리는 service에서 처리해야 함
     private final ProjectStepValidator projectStepValidator;

--- a/module-core/src/main/java/com/back2basics/history/model/DomainType.java
+++ b/module-core/src/main/java/com/back2basics/history/model/DomainType.java
@@ -9,7 +9,8 @@ public enum DomainType {
     PROJECT("프로젝트"),
     COMPANY("업체"),
     STEP("단계"),
-    APPROVAL_REQUEST("승인 요청");
+    APPROVAL_REQUEST("승인 요청"),
+    INQUIRY("관리자 문의");
 
     private final String message;
 

--- a/module-core/src/main/java/com/back2basics/history/model/DomainType.java
+++ b/module-core/src/main/java/com/back2basics/history/model/DomainType.java
@@ -10,7 +10,8 @@ public enum DomainType {
     COMPANY("업체"),
     STEP("단계"),
     APPROVAL_REQUEST("승인 요청"),
-    INQUIRY("관리자 문의");
+    INQUIRY("관리자 문의"),
+    CHECK_LIST("체크리스트");
 
     private final String message;
 

--- a/module-core/src/main/java/com/back2basics/history/model/DomainType.java
+++ b/module-core/src/main/java/com/back2basics/history/model/DomainType.java
@@ -8,7 +8,8 @@ public enum DomainType {
     USER("회원"),
     PROJECT("프로젝트"),
     COMPANY("업체"),
-    STEP("단계");
+    STEP("단계"),
+    APPROVAL_REQUEST("승인 요청");
 
     private final String message;
 

--- a/module-core/src/main/java/com/back2basics/inquiry/model/Inquiry.java
+++ b/module-core/src/main/java/com/back2basics/inquiry/model/Inquiry.java
@@ -1,5 +1,6 @@
 package com.back2basics.inquiry.model;
 
+import com.back2basics.history.strategy.TargetDomain;
 import com.back2basics.inquiry.port.in.command.UpdateInquiryCommand;
 import com.back2basics.inquiry.port.in.command.UpdateInquiryStatusCommand;
 import java.time.LocalDateTime;
@@ -7,7 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class Inquiry {
+public class Inquiry implements TargetDomain {
 
     private final Long id;
     private Long authorId;
@@ -53,6 +54,24 @@ public class Inquiry {
 
     public void markDeleted() {
         this.isDelete = true;
+    }
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    public static Inquiry copyOf(Inquiry original) {
+        return Inquiry.builder()
+            .id(original.getId())
+            .authorId(original.getAuthorId())
+            .title(original.getTitle())
+            .content(original.getContent())
+            .inquiryStatus(original.getInquiryStatus())
+            .createdAt(original.getCreatedAt())
+            .updatedAt(original.getUpdatedAt())
+            .deletedAt(original.getDeletedAt())
+            .build();
     }
 
 }

--- a/module-core/src/main/java/com/back2basics/inquiry/port/in/UpdateInquiryUseCase.java
+++ b/module-core/src/main/java/com/back2basics/inquiry/port/in/UpdateInquiryUseCase.java
@@ -7,6 +7,6 @@ public interface UpdateInquiryUseCase {
 
     void updateByUser(Long inquiryId, Long authorId, UpdateInquiryCommand command);
 
-    void updateByAdmin(Long inquiryId, UpdateInquiryStatusCommand command);
+    void updateByAdmin(Long inquiryId, UpdateInquiryStatusCommand command, Long loggedInUserId);
 
 }

--- a/module-core/src/main/java/com/back2basics/inquiry/port/out/CreateInquiryPort.java
+++ b/module-core/src/main/java/com/back2basics/inquiry/port/out/CreateInquiryPort.java
@@ -4,6 +4,6 @@ import com.back2basics.inquiry.model.Inquiry;
 
 public interface CreateInquiryPort {
 
-    Long save(Inquiry inquiry);
+    Inquiry save(Inquiry inquiry);
 
 }

--- a/module-core/src/main/java/com/back2basics/inquiry/port/out/DeleteInquiryPort.java
+++ b/module-core/src/main/java/com/back2basics/inquiry/port/out/DeleteInquiryPort.java
@@ -4,6 +4,6 @@ import com.back2basics.inquiry.model.Inquiry;
 
 public interface DeleteInquiryPort {
 
-    void softDelete(Inquiry inquiry);
+    Inquiry softDelete(Inquiry inquiry);
 
 }

--- a/module-core/src/main/java/com/back2basics/inquiry/port/out/UpdateInquiryPort.java
+++ b/module-core/src/main/java/com/back2basics/inquiry/port/out/UpdateInquiryPort.java
@@ -4,6 +4,6 @@ import com.back2basics.inquiry.model.Inquiry;
 
 public interface UpdateInquiryPort {
 
-    void update(Inquiry inquiry);
+    Inquiry update(Inquiry inquiry);
 
 }

--- a/module-core/src/main/java/com/back2basics/inquiry/service/CreateInquiryService.java
+++ b/module-core/src/main/java/com/back2basics/inquiry/service/CreateInquiryService.java
@@ -1,5 +1,7 @@
 package com.back2basics.inquiry.service;
 
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
 import com.back2basics.inquiry.model.Inquiry;
 import com.back2basics.inquiry.port.in.CreateInquiryUseCase;
 import com.back2basics.inquiry.port.in.command.CreateInquiryCommand;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 public class CreateInquiryService implements CreateInquiryUseCase {
 
     private final CreateInquiryPort createInquiryPort;
+    private final HistoryLogService historyLogService;
 
     @Override
     public Long createInquiry(CreateInquiryCommand command, Long id) {
@@ -21,7 +24,11 @@ public class CreateInquiryService implements CreateInquiryUseCase {
             .content(command.getContent())
             .build();
 
-        return createInquiryPort.save(inquiry);
+        Inquiry savedInquiry = createInquiryPort.save(inquiry);
+
+        historyLogService.logCreated(DomainType.INQUIRY, id, savedInquiry, "관리자 문의 생성");
+
+        return savedInquiry.getId();
     }
 
 }

--- a/module-core/src/main/java/com/back2basics/inquiry/service/DeleteInquiryService.java
+++ b/module-core/src/main/java/com/back2basics/inquiry/service/DeleteInquiryService.java
@@ -1,5 +1,7 @@
 package com.back2basics.inquiry.service;
 
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
 import com.back2basics.infra.exception.ForbiddenAccessException;
 import com.back2basics.infra.validation.validator.InquiryValidator;
 import com.back2basics.inquiry.model.Inquiry;
@@ -14,18 +16,27 @@ public class DeleteInquiryService implements DeleteInquiryUseCase {
 
     private final DeleteInquiryPort deleteInquiryPort;
     private final InquiryValidator inquiryValidator;
+    private final HistoryLogService historyLogService;
 
+
+    // todo : 의견
+    // swlee: 모든 메소드에서 넘어오는 파라미터의 변수 이름이 다 달라서 너무 혼란스럽습니다.
+    // 똑같이 CustomUserDetails.getId()로 넘어오는 로그인유저아이디인데 어떤건 그냥id 어떤건 userId,
+    // 이름도 다른데 순서까지 일관성이 없어서 너무 헷갈려요 통일하면 좋을 것 같습니다.
     @Override
     public void deleteInquiry(Long inquiryId, Long userId) {
 
         Inquiry inquiry = inquiryValidator.findInquiry(inquiryId);
 
+        // todo : 커스텀익셉션 사용, Validator로 로직 이동
         if (!inquiry.getAuthorId().equals(userId)) {
             throw new ForbiddenAccessException("자신의 문의만 삭제할 수 있습니다.");
         }
 
         inquiry.markDeleted();
-        deleteInquiryPort.softDelete(inquiry);
+        Inquiry deletedInquiry = deleteInquiryPort.softDelete(inquiry);
+
+        historyLogService.logDeleted(DomainType.INQUIRY, userId, deletedInquiry, "문의사항 비활성화");
     }
 
 }

--- a/module-core/src/main/java/com/back2basics/inquiry/service/UpdateInquiryService.java
+++ b/module-core/src/main/java/com/back2basics/inquiry/service/UpdateInquiryService.java
@@ -1,5 +1,7 @@
 package com.back2basics.inquiry.service;
 
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
 import com.back2basics.infra.exception.ForbiddenAccessException;
 import com.back2basics.infra.validation.validator.InquiryValidator;
 import com.back2basics.inquiry.model.Inquiry;
@@ -16,24 +18,35 @@ public class UpdateInquiryService implements UpdateInquiryUseCase {
 
     private final UpdateInquiryPort updateInquiryPort;
     private final InquiryValidator inquiryValidator;
+    private final HistoryLogService historyLogService;
 
     @Override
     public void updateByUser(Long inquiryId, Long authorId, UpdateInquiryCommand command) {
         Inquiry inquiry = inquiryValidator.findInquiry(inquiryId);
+        Inquiry before = Inquiry.copyOf(inquiry);
 
+        // todo : 커스텀익셉션 사용, Validator로 로직 이동
         if (!inquiry.getAuthorId().equals(authorId)) {
             throw new ForbiddenAccessException("자신의 문의만 수정할 수 있습니다.");
         }
 
         inquiry.updateContent(command);
-        updateInquiryPort.update(inquiry);
+        Inquiry savedInquiry = updateInquiryPort.update(inquiry);
+
+        historyLogService.logUpdated(DomainType.INQUIRY, authorId, before, savedInquiry,
+            "문의사항 정보 수정");
     }
 
     @Override
-    public void updateByAdmin(Long inquiryId, UpdateInquiryStatusCommand command) {
+    public void updateByAdmin(Long inquiryId, UpdateInquiryStatusCommand command,
+        Long loggedInUserId) {
         Inquiry inquiry = inquiryValidator.findInquiry(inquiryId);
+        Inquiry before = Inquiry.copyOf(inquiry);
 
         inquiry.updateStatus(command);
-        updateInquiryPort.update(inquiry);
+        Inquiry savedInquiry = updateInquiryPort.update(inquiry);
+
+        historyLogService.logUpdated(DomainType.INQUIRY, loggedInUserId, before, savedInquiry,
+            "문의사항 상태 변경");
     }
 }

--- a/module-core/src/main/java/com/back2basics/todolist/model/TodoList.java
+++ b/module-core/src/main/java/com/back2basics/todolist/model/TodoList.java
@@ -1,10 +1,11 @@
 package com.back2basics.todolist.model;
 
+import com.back2basics.history.strategy.TargetDomain;
 import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
-public class TodoList {
+public class TodoList implements TargetDomain {
 
     private final Long id;
     private String content;
@@ -40,6 +41,22 @@ public class TodoList {
     public void unCheck() {
         this.isChecked = false;
         this.checkedAt = null;
+    }
+
+    @Override
+    public Long getId() {
+        return this.id;
+    }
+
+    public static TodoList copyOf(TodoList original) {
+        return new TodoList(
+            original.getId(),
+            original.getContent(),
+            original.getUserId(),
+            original.getCreatedAt(),
+            original.getCheckedAt(),
+            original.getIsChecked()
+        );
     }
 
 }

--- a/module-core/src/main/java/com/back2basics/todolist/port/in/DeleteTodoListUseCase.java
+++ b/module-core/src/main/java/com/back2basics/todolist/port/in/DeleteTodoListUseCase.java
@@ -2,5 +2,5 @@ package com.back2basics.todolist.port.in;
 
 public interface DeleteTodoListUseCase {
 
-    void delete(Long checkListId);
+    void delete(Long checkListId, Long loggedInUserID);
 }

--- a/module-core/src/main/java/com/back2basics/todolist/port/in/UpdateTodoListUseCase.java
+++ b/module-core/src/main/java/com/back2basics/todolist/port/in/UpdateTodoListUseCase.java
@@ -4,7 +4,7 @@ import com.back2basics.todolist.port.in.command.CreateTodoListCommand;
 
 public interface UpdateTodoListUseCase {
 
-    void update(Long checkListId, CreateTodoListCommand command);
+    void update(Long checkListId, CreateTodoListCommand command, Long loggedInUserID);
 
-    void check(Long checkListId);
+    void check(Long checkListId, Long loggedInUserID);
 }

--- a/module-core/src/main/java/com/back2basics/todolist/port/out/TodoListCommandPort.java
+++ b/module-core/src/main/java/com/back2basics/todolist/port/out/TodoListCommandPort.java
@@ -4,7 +4,7 @@ import com.back2basics.todolist.model.TodoList;
 
 public interface TodoListCommandPort {
 
-    void save(TodoList todoList);
+    TodoList save(TodoList todoList);
 
     void delete(Long checkListId);
 }

--- a/module-core/src/main/java/com/back2basics/todolist/service/CreateTodoListService.java
+++ b/module-core/src/main/java/com/back2basics/todolist/service/CreateTodoListService.java
@@ -1,5 +1,7 @@
 package com.back2basics.todolist.service;
 
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
 import com.back2basics.todolist.model.TodoList;
 import com.back2basics.todolist.port.in.CreateTodoListUseCase;
 import com.back2basics.todolist.port.in.command.CreateTodoListCommand;
@@ -12,10 +14,13 @@ import org.springframework.stereotype.Service;
 public class CreateTodoListService implements CreateTodoListUseCase {
 
     private final TodoListCommandPort todoListCommandPort;
+    private final HistoryLogService historyLogService;
 
     @Override
     public void create(Long userId, CreateTodoListCommand command) {
         TodoList todoList = TodoList.create(command.content(), userId);
-        todoListCommandPort.save(todoList);
+        TodoList savedTodoList = todoListCommandPort.save(todoList);
+
+        historyLogService.logCreated(DomainType.CHECK_LIST, userId, savedTodoList, "체크리스트 신규 등록");
     }
 }

--- a/module-core/src/main/java/com/back2basics/todolist/service/DeleteTodoListService.java
+++ b/module-core/src/main/java/com/back2basics/todolist/service/DeleteTodoListService.java
@@ -1,7 +1,11 @@
 package com.back2basics.todolist.service;
 
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
+import com.back2basics.todolist.model.TodoList;
 import com.back2basics.todolist.port.in.DeleteTodoListUseCase;
 import com.back2basics.todolist.port.out.TodoListCommandPort;
+import com.back2basics.todolist.port.out.TodoListQueryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,9 +14,15 @@ import org.springframework.stereotype.Service;
 public class DeleteTodoListService implements DeleteTodoListUseCase {
 
     private final TodoListCommandPort todoListCommandPort;
+    private final TodoListQueryPort todoListQueryPort;
+    private final HistoryLogService historyLogService;
 
     @Override
-    public void delete(Long checkListId) {
+    public void delete(Long checkListId, Long loggedInUserId) {
         todoListCommandPort.delete(checkListId);
+        
+        TodoList deletedTodoList = todoListQueryPort.findById(checkListId);
+        historyLogService.logDeleted(DomainType.CHECK_LIST, loggedInUserId, deletedTodoList,
+            "체크리스트 삭제");
     }
 }

--- a/module-core/src/main/java/com/back2basics/todolist/service/UpdateTodoListService.java
+++ b/module-core/src/main/java/com/back2basics/todolist/service/UpdateTodoListService.java
@@ -1,5 +1,7 @@
 package com.back2basics.todolist.service;
 
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
 import com.back2basics.todolist.model.TodoList;
 import com.back2basics.todolist.port.in.UpdateTodoListUseCase;
 import com.back2basics.todolist.port.in.command.CreateTodoListCommand;
@@ -14,17 +16,22 @@ public class UpdateTodoListService implements UpdateTodoListUseCase {
 
     private final TodoListCommandPort todoListCommandPort;
     private final TodoListQueryPort todoListQueryPort;
+    private final HistoryLogService historyLogService;
 
     @Override
-    public void update(Long checkListId, CreateTodoListCommand command) {
+    public void update(Long checkListId, CreateTodoListCommand command, Long loggedInUserId) {
         TodoList todoList = todoListQueryPort.findById(checkListId);
+        TodoList before = TodoList.copyOf(todoList);
         todoList.update(command.content());
-        todoListCommandPort.save(todoList);
+
+        historyLogService.logUpdated(DomainType.CHECK_LIST, loggedInUserId, before, todoList,
+            "체크리스트 정보 변경");
     }
 
     @Override
-    public void check(Long checkListId) {
+    public void check(Long checkListId, Long loggedInUserId) {
         TodoList todoList = todoListQueryPort.findById(checkListId);
+        TodoList before = TodoList.copyOf(todoList);
 
         if (todoList.getIsChecked()) {
             todoList.unCheck();
@@ -33,5 +40,8 @@ public class UpdateTodoListService implements UpdateTodoListUseCase {
         }
 
         todoListCommandPort.save(todoList);
+
+        historyLogService.logUpdated(DomainType.CHECK_LIST, loggedInUserId, before, todoList,
+            "체크리스트 정보 변경");
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/approval/adapter/ApprovalRequestCommandAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/approval/adapter/ApprovalRequestCommandAdapter.java
@@ -29,7 +29,7 @@ public class ApprovalRequestCommandAdapter implements ApprovalRequestCommandPort
     private final ApprovalResponseEntityRepository approvalResponseEntityRepository;
 
     @Override
-    public Long create(ApprovalRequest approvalRequest) {
+    public ApprovalRequest create(ApprovalRequest approvalRequest) {
 
         // 실제 쿼리를 즉시 실행하지 않고, 해당 ID에 대한 지연 프록시 객체 반환
         // 실제 값이 필요할 때까지 DB에 접근하지 않음
@@ -51,7 +51,7 @@ public class ApprovalRequestCommandAdapter implements ApprovalRequestCommandPort
 
         entity.addResponses(responses);
         approvalRequestEntityRepository.save(entity);
-        return entity.getId();
+        return mapper.toDomain(entity);
     }
 
     @Override
@@ -84,7 +84,7 @@ public class ApprovalRequestCommandAdapter implements ApprovalRequestCommandPort
             approvalRequest.getRequesterId());
         List<ApprovalResponseEntity> approvalResponseEntities = approvalResponseEntityRepository.findAllByApprovalRequestId(
             approvalRequest.getId());
-        
+
         approvalRequestEntityRepository.save(
             mapper.toEntity(approvalRequest, projectStepEntity, requester,
                 approvalResponseEntities));

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/approval/entity/ApprovalRequestEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/approval/entity/ApprovalRequestEntity.java
@@ -75,6 +75,10 @@ public class ApprovalRequestEntity {
     }
 
     public void addResponses(List<ApprovalResponseEntity> newApprovers) {
+        if (this.responses == null) {
+            this.responses = new ArrayList<>();
+        }
+
         List<Long> existingApproverIds = this.responses.stream()
             .map(response -> response.getApprover().getId())
             .toList();

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/inquiry/adapter/CreateInquiryJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/inquiry/adapter/CreateInquiryJpaAdapter.java
@@ -16,9 +16,9 @@ public class CreateInquiryJpaAdapter implements CreateInquiryPort {
     private final InquiryMapper inquiryMapper;
 
     @Override
-    public Long save(Inquiry inquiry) {
+    public Inquiry save(Inquiry inquiry) {
         InquiryEntity entity = inquiryMapper.toEntity(inquiry);
-        return inquiryEntityRepository.save(entity).getId();
+        return inquiryMapper.toDomain(inquiryEntityRepository.save(entity));
     }
 
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/inquiry/adapter/DeleteInquiryJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/inquiry/adapter/DeleteInquiryJpaAdapter.java
@@ -2,6 +2,7 @@ package com.back2basics.adapter.persistence.inquiry.adapter;
 
 import com.back2basics.adapter.persistence.inquiry.InquiryEntity;
 import com.back2basics.adapter.persistence.inquiry.InquiryEntityRepository;
+import com.back2basics.adapter.persistence.inquiry.InquiryMapper;
 import com.back2basics.infra.exception.inquiry.InquiryErrorCode;
 import com.back2basics.infra.exception.inquiry.InquiryException;
 import com.back2basics.inquiry.model.Inquiry;
@@ -13,14 +14,17 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class DeleteInquiryJpaAdapter implements DeleteInquiryPort {
 
+    private final InquiryMapper inquiryMapper;
     private final InquiryEntityRepository inquiryEntityRepository;
 
-    public void softDelete(Inquiry inquiry) {
+    public Inquiry softDelete(Inquiry inquiry) {
         InquiryEntity inquiryEntity = inquiryEntityRepository.findById(inquiry.getId())
             .orElseThrow(() -> new InquiryException(InquiryErrorCode.INQUIRY_NOT_FOUND));
 
         inquiryEntity.markDeleted();
         inquiryEntityRepository.save(inquiryEntity);
+
+        return inquiryMapper.toDomain(inquiryEntityRepository.save(inquiryEntity));
     }
 
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/inquiry/adapter/UpdateInquiryJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/inquiry/adapter/UpdateInquiryJpaAdapter.java
@@ -15,8 +15,10 @@ public class UpdateInquiryJpaAdapter implements UpdateInquiryPort {
     private final InquiryMapper inquiryMapper;
 
     @Override
-    public void update(Inquiry inquiry) {
-        inquiryEntityRepository.save(inquiryMapper.toEntity(inquiry));
+    public Inquiry update(Inquiry inquiry) {
+
+        return inquiryMapper.toDomain(
+            inquiryEntityRepository.save(inquiryMapper.toEntity(inquiry)));
     }
 
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/todolist/adapter/TodoTodoListCommandAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/todolist/adapter/TodoTodoListCommandAdapter.java
@@ -23,10 +23,10 @@ public class TodoTodoListCommandAdapter implements TodoListCommandPort {
     private final PostEntityRepository postEntityRepository;
 
     @Override
-    public void save(TodoList todoList) {
+    public TodoList save(TodoList todoList) {
         UserEntity user = userEntityRepository.getReferenceById(todoList.getUserId());
         TodoListEntity todoListEntity = mapper.toEntity(todoList, user);
-        todoListEntityRepository.save(todoListEntity);
+        return mapper.toDomain(todoListEntityRepository.save(todoListEntity));
     }
 
     @Override


### PR DESCRIPTION
## 📌 개요
승인 요청, 관리자 문의/답변, 체크리스트 도메인에 이력 로그 기능 추가 및 관련 오류 수정

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 승인 요청 생성/수정 시 이력 기록 기능 추가
- 관리자 문의 및 답변 작성 시 이력 기록 기능 추가
- 체크리스트 생성/변경 시 이력 기록 기능 추가
- `CreateApprovalRequestService` 클래스명 오타 수정
- 히스토리 기록을 위해 포트 리턴 타입을 `Entity`로 수정
- null 가능 필드에 stream() 호출 전 null 체크 추가

## 🔍 관련 이슈
- Close #456

## 🧪 테스트 결과
- 승인 요청 생성/수정 후 MongoDB에 이력 기록 확인
- 문의/답변 및 체크리스트 변경 시 이력 정상 저장 확인

## 👀 리뷰어에게 요청사항
- 각 도메인의 변경 전/후 이력 정보가 정확히 반영되는지 확인 부탁드립니다

## 📎 기타 참고 사항
- 없음