### PR TITLE
[Feature] 게시글 제목 및 내용 길이 제한 추가, 이력 필터 기능 개선 및 SQL 로그 중복 출력 문제 해결

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/history/dto/request/HistorySearchRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/history/dto/request/HistorySearchRequest.java
@@ -3,6 +3,7 @@ package com.back2basics.domain.history.dto.request;
 import com.back2basics.history.model.DomainType;
 import com.back2basics.history.model.HistoryType;
 import com.back2basics.history.port.in.command.HistorySearchCommand;
+import com.back2basics.user.model.Role;
 import jakarta.annotation.Nullable;
 import java.time.LocalDateTime;
 
@@ -10,13 +11,14 @@ public record HistorySearchRequest(
     @Nullable HistoryType historyType,
     @Nullable DomainType domainType,
     @Nullable String changedBy,
+    @Nullable Role changerRole,
     @Nullable LocalDateTime changedFrom,
     @Nullable LocalDateTime changedTo
 
 ) {
 
     public HistorySearchCommand toCommand() {
-        return new HistorySearchCommand(historyType, domainType, changedBy, changedFrom,
+        return new HistorySearchCommand(historyType, domainType, changedBy, changerRole, changedFrom,
             changedTo);
     }
 }

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -90,7 +90,7 @@ spring:
       ddl-auto: update
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true

--- a/module-core/src/main/java/com/back2basics/history/port/in/command/HistorySearchCommand.java
+++ b/module-core/src/main/java/com/back2basics/history/port/in/command/HistorySearchCommand.java
@@ -2,12 +2,14 @@ package com.back2basics.history.port.in.command;
 
 import com.back2basics.history.model.DomainType;
 import com.back2basics.history.model.HistoryType;
+import com.back2basics.user.model.Role;
 import java.time.LocalDateTime;
 
 public record HistorySearchCommand(
     HistoryType historyType,
     DomainType domainType,
     String changedBy,
+    Role changerRole,
     LocalDateTime changedFrom,
     LocalDateTime changedTo
 ) {

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/PostEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/PostEntity.java
@@ -41,10 +41,10 @@ public class PostEntity extends BaseTimeEntity {
     @Column(name = "project_step_id", nullable = false)
     private Long projectStepId;
 
-    @Column(name = "title", nullable = false)
+    @Column(name = "title", nullable = false, length = 50)
     private String title;
 
-    @Column(name = "content", nullable = false, length = 10000)
+    @Column(name = "content", nullable = false, length = 3000)
     private String content;
 
     @Enumerated(EnumType.STRING)

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistoryDocument.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistoryDocument.java
@@ -26,7 +26,7 @@ public class HistoryDocument {
     private DomainType domainType; // user, project, step, post ...
 
     @Field("domain_id")
-    private String domainId;   // 얘는 어케해야되냐 string <-> long
+    private String domainId;
 
     @Field("changed_at")
     private LocalDateTime changedAt;

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistorySearchAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistorySearchAdapter.java
@@ -48,9 +48,9 @@ public class HistorySearchAdapter implements HistorySearchPort {
 
         addIfPresent(filters, "historyType", command.historyType());
         addIfPresent(filters, "domainType", command.domainType());
-        addIfPresent(filters, "changedBy", command.changedBy());
         addIfPresent(filters, "changerRole", command.changerRole());
 
+        // 날짜 조건(언제부터 언제까지 발생한 이력인지)
         if (command.changedFrom() != null && command.changedTo() != null) {
             filters.add(Criteria.where("changed_at")
                 .gte(command.changedFrom())
@@ -59,7 +59,10 @@ public class HistorySearchAdapter implements HistorySearchPort {
             filters.add(Criteria.where("changed_at").gte(command.changedFrom()));
         } else if (command.changedTo() != null) {
             filters.add(Criteria.where("changed_at").lte(command.changedTo()));
-        } else if (command.changedBy() != null ){
+        }
+
+        // 변경자 검색 조건 -> username, name 둘 다 모두 검색 가능하게끔
+        if (command.changedBy() != null) {
             filters.add(new Criteria().orOperator(
                 Criteria.where("changer_username").is(command.changedBy()),
                 Criteria.where("changer_name").is(command.changedBy())

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistorySearchAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistorySearchAdapter.java
@@ -7,12 +7,12 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,13 +29,16 @@ public class HistorySearchAdapter implements HistorySearchPort {
         query.with(pageable).with(Sort.by(Sort.Direction.DESC, "history_created_at"));
 
         List<HistoryDocument> documents = mongoTemplate.find(query, HistoryDocument.class);
-        long total = mongoTemplate.count(new Query(criteria), HistoryDocument.class);
 
         List<HistorySimpleResult> results = documents.stream()
             .map(HistoryMapper::toSimpleResult)
             .toList();
 
-        return new PageImpl<>(results, pageable, total);
+        return PageableExecutionUtils.getPage(
+            results,
+            pageable,
+            () -> mongoTemplate.count(new Query(criteria), HistoryDocument.class)
+        );
     }
 
 


### PR DESCRIPTION
## 📌 개요
게시글 제목 및 내용 길이 제한 추가, 이력 필터 기능 개선 및 SQL 로그 중복 출력 문제 해결

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 게시글 제목(title), 내용(content) 길이 제한 설정 (`@Column(length = ...)`)
- 이력 필터 조건 중 중복 필터링이 적용되지 않던 문제 해결
- 변경자 이름(changerName), 아이디(changerUsername)로 검색 조건 확장
- MongoDB 이력 검색 시 `PageableExecutionUtils` 적용으로 페이지네이션 로직 개선
- application.yml 수정으로 Hibernate SQL 로그 2회 출력 문제 해결

## 🔍 관련 이슈
- Close #473

## 🧪 테스트 결과

## 👀 리뷰어에게 요청사항


## 📎 기타 참고 사항