### PR TITLE
[Refactor] 첨부파일 업로드/다운로드를 presignedURL 방식으로 개선

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
@@ -2,6 +2,7 @@ package com.back2basics.domain.board.controller;
 
 import com.back2basics.board.file.port.in.FileDownloadUseCase;
 import com.back2basics.board.file.service.FileDownloadResult;
+import com.back2basics.board.file.service.FilePresignedUrlResult;
 import com.back2basics.board.post.port.in.PostCreateUseCase;
 import com.back2basics.board.post.port.in.PostDeleteUseCase;
 import com.back2basics.board.post.port.in.PostReadUseCase;
@@ -251,5 +252,18 @@ public class PostController /*implements PostApiDocs*/ {
         );
 
         return ApiResponse.success(PostResponseCode.POST_UPDATE_PRESIGNED_SUCCESS);
+    }
+
+    @GetMapping("/{postId}/files/{fileId}/presigned")
+    public ResponseEntity<ApiResponse<String>> getFilePresignedDownloadUrl(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @PathVariable Long postId,
+        @PathVariable Long fileId
+    ) {
+        FilePresignedUrlResult result = fileDownloadUseCase.getPresignedDownloadUrl(
+            customUserDetails.getId(), postId, fileId
+        );
+
+        return ApiResponse.success(PostResponseCode.POST_FILE_PRESIGNED_URL_SUCCESS, result.presignedUrl());
     }
 }

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
@@ -222,6 +222,9 @@ public class PostController /*implements PostApiDocs*/ {
     ) {
         Long userId = customUserDetails.getId();
         String userIp = customUserDetails.getIp();
+
+        log.info("========================url : {}", request.getUploadedFiles().get(0).getUrl());
+        log.info("========================url : {}", request.getUploadedFiles().get(0).getUrl());
         PostCreateResult result = createPostUseCase.createPostWithPresigned(
             userId,
             request.getProjectId(),

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
@@ -14,6 +14,7 @@ import com.back2basics.board.post.service.result.PostSummaryReadResult;
 import com.back2basics.board.post.service.result.ReadRecentPostResult;
 import com.back2basics.domain.board.controller.code.PostResponseCode;
 import com.back2basics.domain.board.dto.request.PostCreateRequest;
+import com.back2basics.domain.board.dto.request.PostCreateWithPresignedRequest;
 import com.back2basics.domain.board.dto.request.PostSearchRequest;
 import com.back2basics.domain.board.dto.request.PostUpdateRequest;
 import com.back2basics.domain.board.dto.response.PostCreateResponse;
@@ -41,6 +42,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -209,5 +211,24 @@ public class PostController /*implements PostApiDocs*/ {
 
         return ApiResponse.success(PostResponseCode.POST_READ_ALL_DASHBOARD_SUCCESS, responseList);
 
+    }
+
+    @PostMapping("/presigned")
+    public ResponseEntity<ApiResponse<PostCreateResponse>> createPostWithPresigned(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @RequestBody @Valid PostCreateWithPresignedRequest request
+    ) {
+        Long userId = customUserDetails.getId();
+        String userIp = customUserDetails.getIp();
+        PostCreateResult result = createPostUseCase.createPostWithPresigned(
+            userId,
+            request.getProjectId(),
+            request.getStepId(),
+            userIp,
+            request.toCommand(),
+            request.toUploadedFileInfos()
+        );
+        PostCreateResponse response = PostCreateResponse.toResponse(result);
+        return ApiResponse.success(PostResponseCode.POST_CREATE_PRESIGNED_SUCCESS, response);
     }
 }

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
@@ -17,6 +17,7 @@ import com.back2basics.domain.board.dto.request.PostCreateRequest;
 import com.back2basics.domain.board.dto.request.PostCreateWithPresignedRequest;
 import com.back2basics.domain.board.dto.request.PostSearchRequest;
 import com.back2basics.domain.board.dto.request.PostUpdateRequest;
+import com.back2basics.domain.board.dto.request.PostUpdateWithPresignedRequest;
 import com.back2basics.domain.board.dto.response.PostCreateResponse;
 import com.back2basics.domain.board.dto.response.PostDashboardReadResponse;
 import com.back2basics.domain.board.dto.response.PostDetailReadResponse;
@@ -230,5 +231,25 @@ public class PostController /*implements PostApiDocs*/ {
         );
         PostCreateResponse response = PostCreateResponse.toResponse(result);
         return ApiResponse.success(PostResponseCode.POST_CREATE_PRESIGNED_SUCCESS, response);
+    }
+
+    @PutMapping("/{postId}/presigned")
+    public ResponseEntity<ApiResponse<Void>> updatePostWithPresigned(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @PathVariable Long postId,
+        @RequestBody @Valid PostUpdateWithPresignedRequest request
+    ) {
+        Long userId = customUserDetails.getId();
+        String userIp = customUserDetails.getIp();
+
+        postUpdateUseCase.updatePostWithPresigned(
+            userId,
+            userIp,
+            postId,
+            request.toCommand(),
+            request.toUploadedFileInfos()
+        );
+
+        return ApiResponse.success(PostResponseCode.POST_UPDATE_PRESIGNED_SUCCESS);
     }
 }

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
@@ -15,10 +15,10 @@ public enum PostResponseCode implements ResponseCode {
     POST_UPDATE_SUCCESS(HttpStatus.OK, "P204", "게시글 수정 완료"),
     POST_DELETE_SUCCESS(HttpStatus.OK, "P205", "게시글 삭제 완료"),
     POST_FILE_DOWNLOAD_SUCCESS(HttpStatus.OK, "PF206", "파일 다운로드 완료"),
-    POST_READ_ALL_DASHBOARD_SUCCESS(HttpStatus.OK, "P207", "진행중인 프로젝트에 등록된 게시글 목록 조회 완료");
+    POST_READ_ALL_DASHBOARD_SUCCESS(HttpStatus.OK, "P207", "진행중인 프로젝트에 등록된 게시글 목록 조회 완료"),
+    POST_CREATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P208", "Presigned URL 기반 게시글 생성 완료");
 
     private final HttpStatus status;
     private final String code;
     private final String message;
 }
-

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
@@ -17,7 +17,8 @@ public enum PostResponseCode implements ResponseCode {
     POST_FILE_DOWNLOAD_SUCCESS(HttpStatus.OK, "PF206", "파일 다운로드 완료"),
     POST_READ_ALL_DASHBOARD_SUCCESS(HttpStatus.OK, "P207", "진행중인 프로젝트에 등록된 게시글 목록 조회 완료"),
     POST_CREATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P208", "Presigned URL 기반 게시글 생성 완료"),
-    POST_UPDATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P209", "Presigned URL 기반 게시글 수정 완료");
+    POST_UPDATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P209", "Presigned URL 기반 게시글 수정 완료"),
+    POST_FILE_PRESIGNED_URL_SUCCESS(HttpStatus.OK,"PF206", "파일 다운로드 URL 발급 완료");
 
     private final HttpStatus status;
     private final String code;

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
@@ -16,7 +16,8 @@ public enum PostResponseCode implements ResponseCode {
     POST_DELETE_SUCCESS(HttpStatus.OK, "P205", "게시글 삭제 완료"),
     POST_FILE_DOWNLOAD_SUCCESS(HttpStatus.OK, "PF206", "파일 다운로드 완료"),
     POST_READ_ALL_DASHBOARD_SUCCESS(HttpStatus.OK, "P207", "진행중인 프로젝트에 등록된 게시글 목록 조회 완료"),
-    POST_CREATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P208", "Presigned URL 기반 게시글 생성 완료");
+    POST_CREATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P208", "Presigned URL 기반 게시글 생성 완료"),
+    POST_UPDATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P209", "Presigned URL 기반 게시글 수정 완료");
 
     private final HttpStatus status;
     private final String code;

--- a/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostCreateWithPresignedRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostCreateWithPresignedRequest.java
@@ -1,0 +1,66 @@
+package com.back2basics.domain.board.dto.request;
+
+import com.back2basics.board.post.model.PostPriority;
+import com.back2basics.board.post.model.PostType;
+import com.back2basics.board.post.port.in.command.PostCreateCommand;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
+import com.back2basics.infra.validation.custom.CustomEnumCheck;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PostCreateWithPresignedRequest {
+
+    @Nullable
+    private Long parentId;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    @NotNull(message = "타입이 입력되지 않았습니다.")
+    @CustomEnumCheck(enumClass = PostType.class, message = "올바른 enum type이 아닙니다")
+    private PostType type;
+
+    @NotNull(message = "우선순위가 입력되지 않았습니다.")
+    @CustomEnumCheck(enumClass = PostPriority.class, message = "올바른 enum type이 아닙니다")
+    private PostPriority priority;
+
+    @NotNull(message = "프로젝트를 입력하세요.")
+    private Long projectId;
+
+    @NotNull(message = "프로젝트 단계를 입력하세요.")
+    private Long stepId;
+
+    private List<String> newLinks = List.of();
+    private List<PresignedUploadedFileRequest> uploadedFiles;
+
+    public PostCreateCommand toCommand() {
+        return PostCreateCommand.builder()
+            .parentId(parentId)
+            .title(title)
+            .content(content)
+            .priority(priority)
+            .projectId(projectId)
+            .stepId(stepId)
+            .type(type)
+            .newLinks(newLinks)
+            .build();
+    }
+
+    public List<PresignedUploadCompleteInfo> toUploadedFileInfos() {
+        return this.uploadedFiles.stream()
+            .map(file -> PresignedUploadCompleteInfo.of(
+                file.getOriginalName(),
+                file.getUrl(),
+                file.getExtension(),
+                file.getSize()
+            ))
+            .toList();
+    }
+}

--- a/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostUpdateWithPresignedRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostUpdateWithPresignedRequest.java
@@ -1,0 +1,61 @@
+package com.back2basics.domain.board.dto.request;
+
+import com.back2basics.board.post.model.PostPriority;
+import com.back2basics.board.post.model.PostType;
+import com.back2basics.board.post.port.in.command.PostUpdateCommand;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
+import com.back2basics.infra.validation.custom.CustomEnumCheck;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PostUpdateWithPresignedRequest {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    @NotNull(message = "타입이 입력되지 않았습니다.")
+    @CustomEnumCheck(enumClass = PostType.class, message = "올바른 enum type이 아닙니다")
+    private PostType type;
+
+    @NotNull(message = "우선순위가 입력되지 않았습니다.")
+    @CustomEnumCheck(enumClass = PostPriority.class, message = "올바른 enum type이 아닙니다")
+    private PostPriority priority;
+
+    @NotNull(message = "단계가 입력되지 않았습니다.")
+    private Long stepId;
+
+    private List<Long> fileIdsToDelete;
+    private List<Long> linkIdsToDelete;
+    private List<String> newLinks;
+    private List<PresignedUploadedFileRequest> uploadedFiles;
+
+    public PostUpdateCommand toCommand() {
+        return PostUpdateCommand.builder()
+            .title(title)
+            .content(content)
+            .type(type)
+            .priority(priority)
+            .stepId(stepId)
+            .fileIdsToDelete(fileIdsToDelete)
+            .linkIdsToDelete(linkIdsToDelete)
+            .newLinks(newLinks)
+            .build();
+    }
+
+    public List<PresignedUploadCompleteInfo> toUploadedFileInfos() {
+        return this.uploadedFiles.stream()
+            .map(file -> PresignedUploadCompleteInfo.of(
+                file.getOriginalName(),
+                file.getUrl(),
+                file.getExtension(),
+                file.getSize()
+            ))
+            .toList();
+    }
+}

--- a/module-api/src/main/java/com/back2basics/domain/board/dto/request/PresignedUploadedFileRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/dto/request/PresignedUploadedFileRequest.java
@@ -1,0 +1,11 @@
+package com.back2basics.domain.board.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class PresignedUploadedFileRequest {
+    private String originalName;
+    private String url;
+    private String extension;
+    private String size;
+}

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -63,6 +63,7 @@ cloudflare:
     bucket: ${R2_BUCKET}
     access-key: ${R2_ACCESS_KEY}
     secret-key: ${R2_SECRET_KEY}
+    public-url: ${R2_PUBLIC_URL}
 
   servlet:
     multipart:

--- a/module-core/src/main/java/com/back2basics/board/file/model/File.java
+++ b/module-core/src/main/java/com/back2basics/board/file/model/File.java
@@ -38,4 +38,10 @@ public class File {
     public File withFileType(String newType) {
         return new File(this.id, this.postId, this.fileName, this.fileUrl, newType, this.fileSize);
     }
+
+    public String getFileKey() {
+        String prefix = "https://danmuji." + "[YOUR_R2_SUBDOMAIN]" + ".r2.cloudflarestorage.com/";
+        return fileUrl.replace(prefix, "");
+    }
+
 }

--- a/module-core/src/main/java/com/back2basics/board/file/port/in/FileDownloadUseCase.java
+++ b/module-core/src/main/java/com/back2basics/board/file/port/in/FileDownloadUseCase.java
@@ -1,9 +1,12 @@
 package com.back2basics.board.file.port.in;
 
 import com.back2basics.board.file.service.FileDownloadResult;
+import com.back2basics.board.file.service.FilePresignedUrlResult;
 import java.io.IOException;
 
 public interface FileDownloadUseCase {
 
     FileDownloadResult downloadFile(Long userId, Long postId, Long fileId) throws IOException;
+
+    FilePresignedUrlResult getPresignedDownloadUrl(Long userId, Long postId, Long fileId);
 }

--- a/module-core/src/main/java/com/back2basics/board/file/port/out/FilePresignedUrlPort.java
+++ b/module-core/src/main/java/com/back2basics/board/file/port/out/FilePresignedUrlPort.java
@@ -1,0 +1,5 @@
+package com.back2basics.board.file.port.out;
+
+public interface FilePresignedUrlPort {
+    String generateDownloadUrl(String fileKey);
+}

--- a/module-core/src/main/java/com/back2basics/board/file/service/FilePresignedUrlResult.java
+++ b/module-core/src/main/java/com/back2basics/board/file/service/FilePresignedUrlResult.java
@@ -1,0 +1,3 @@
+package com.back2basics.board.file.service;
+
+public record FilePresignedUrlResult(String presignedUrl) {}

--- a/module-core/src/main/java/com/back2basics/board/post/port/in/PostCreateUseCase.java
+++ b/module-core/src/main/java/com/back2basics/board/post/port/in/PostCreateUseCase.java
@@ -2,6 +2,7 @@ package com.back2basics.board.post.port.in;
 
 import com.back2basics.board.post.port.in.command.PostCreateCommand;
 import com.back2basics.board.post.service.result.PostCreateResult;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,4 +11,7 @@ public interface PostCreateUseCase {
 
     PostCreateResult createPost(Long userId, Long projectId, Long projectStepId, String userIp,
         PostCreateCommand command, List<MultipartFile> files) throws IOException;
+
+    PostCreateResult createPostWithPresigned(Long userId, Long projectId, Long stepId,
+        String userIp, PostCreateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles);
 }

--- a/module-core/src/main/java/com/back2basics/board/post/port/in/PostUpdateUseCase.java
+++ b/module-core/src/main/java/com/back2basics/board/post/port/in/PostUpdateUseCase.java
@@ -1,12 +1,26 @@
 package com.back2basics.board.post.port.in;
 
 import com.back2basics.board.post.port.in.command.PostUpdateCommand;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface PostUpdateUseCase {
 
-    void updatePost(Long userId, String userIp, Long postId, PostUpdateCommand command,
-        List<MultipartFile> files) throws IOException;
+    void updatePost(
+        Long userId,
+        String userIp,
+        Long postId,
+        PostUpdateCommand command,
+        List<MultipartFile> files
+    ) throws IOException;
+
+    void updatePostWithPresigned(
+        Long userId,
+        String userIp,
+        Long postId,
+        PostUpdateCommand command,
+        List<PresignedUploadCompleteInfo> uploadedFiles
+    );
 }

--- a/module-core/src/main/java/com/back2basics/board/post/service/PostCreateService.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/PostCreateService.java
@@ -20,10 +20,12 @@ import com.back2basics.mention.MentionNotificationSender;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PostCreateService implements PostCreateUseCase {
@@ -73,6 +75,8 @@ public class PostCreateService implements PostCreateUseCase {
         Post post = Post.createFromCommand(command, userId, userIp);
         Post savedPost = postCreatePort.save(post);
 
+        log.info("======================== createPostWithPresigned() 의 url : {}", uploadedFiles.get(0).getUrl());
+
         saveFilesFromPresignedUrls(uploadedFiles, savedPost.getId());
 
         linkCreateService.createLinks(command.getNewLinks(), savedPost.getId());
@@ -87,6 +91,7 @@ public class PostCreateService implements PostCreateUseCase {
     private void saveFilesFromPresignedUrls(List<PresignedUploadCompleteInfo> uploadedFiles, Long postId) {
         if (uploadedFiles == null || uploadedFiles.isEmpty()) return;
 
+        log.info("======================== saveFilesFromPresignedUrls() 의 url : {}", uploadedFiles.get(0).getUrl());
         List<File> fileModels = uploadedFiles.stream()
             .map(info -> File.create(
                 null,
@@ -97,6 +102,7 @@ public class PostCreateService implements PostCreateUseCase {
                 info.getSize()
             )).toList();
         fileSavePort.saveAll(fileModels, postId);
+        log.info("======================== after fileSavePort.saveAll(fileModels, postId)의 url : {}", uploadedFiles.get(0).getUrl());
     }
 
     private void uploadAndSaveFiles(List<MultipartFile> files, Long postId) throws IOException {

--- a/module-core/src/main/java/com/back2basics/infra/exception/file/FileErrorCode.java
+++ b/module-core/src/main/java/com/back2basics/infra/exception/file/FileErrorCode.java
@@ -12,7 +12,10 @@ public enum FileErrorCode implements ErrorCode {
 
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "파일을 찾을 수 없습니다."),
     FILE_DOWNLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "F002", "파일 다운로드 실패"),
-    FILE_DOWNLOAD_DENIED(HttpStatus.FORBIDDEN, "F003", "파일 다운로드 권한이 없습니다.");
+    FILE_DOWNLOAD_DENIED(HttpStatus.FORBIDDEN, "F003", "파일 다운로드 권한이 없습니다."),
+    FILE_DELETE_FAILED_URL_EMPTY(HttpStatus.BAD_REQUEST, "F004", "파일 URL이 null이거나 비어 있습니다."),
+    FILE_DELETE_FAILED_WRONG_URL(HttpStatus.BAD_REQUEST, "F004", "파일 URL이 잘못된 형식입니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/module-core/src/main/java/com/back2basics/infra/s3/dto/PresignedUploadCompleteInfo.java
+++ b/module-core/src/main/java/com/back2basics/infra/s3/dto/PresignedUploadCompleteInfo.java
@@ -1,0 +1,20 @@
+package com.back2basics.infra.s3.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PresignedUploadCompleteInfo {
+    private String originalName;
+    private String url;
+    private String extension;
+    private String size;
+
+    public static PresignedUploadCompleteInfo of(String originalName, String url, String extension, String size) {
+        PresignedUploadCompleteInfo info = new PresignedUploadCompleteInfo();
+        info.originalName = originalName;
+        info.url = url;
+        info.extension = extension;
+        info.size = size;
+        return info;
+    }
+}

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/FileMapper.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/FileMapper.java
@@ -2,8 +2,10 @@ package com.back2basics.adapter.persistence.board.file;
 
 
 import com.back2basics.board.file.model.File;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class FileMapper {
 
@@ -19,6 +21,7 @@ public class FileMapper {
     }
 
     public FileEntity toEntity(File file, Long postId) {
+        log.info("===FileMapper의 toEntity() url: {}", file.getFileUrl());
         return new FileEntity(
             file.getId(),
             postId,

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/FileDeleteAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/FileDeleteAdapter.java
@@ -1,9 +1,13 @@
 package com.back2basics.adapter.persistence.board.file.adapter;
 
+import static com.back2basics.infra.exception.file.FileErrorCode.FILE_DELETE_FAILED_URL_EMPTY;
+import static com.back2basics.infra.exception.file.FileErrorCode.FILE_DELETE_FAILED_WRONG_URL;
+
 import com.back2basics.adapter.persistence.board.file.FileEntityRepository;
-import com.back2basics.infra.s3.S3Util;
 import com.back2basics.board.file.model.File;
 import com.back2basics.board.file.port.out.FileDeletePort;
+import com.back2basics.infra.exception.file.FileException;
+import com.back2basics.infra.s3.S3Util;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +48,13 @@ public class FileDeleteAdapter implements FileDeletePort {
     }
 
     private String extractKeyFromUrl(String url) {
-        // 예시: https://domain/uuid_filename.ext → uuid_filename.ext
-        return url.substring(url.lastIndexOf("/") + 1);
+        if (url == null || url.isBlank()) {
+            throw new FileException(FILE_DELETE_FAILED_URL_EMPTY);
+        }
+        int lastSlash = url.lastIndexOf("/");
+        if (lastSlash == -1 || lastSlash == url.length() - 1) {
+            throw new FileException(FILE_DELETE_FAILED_WRONG_URL);
+        }
+        return url.substring(lastSlash + 1);
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/FileSaveAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/FileSaveAdapter.java
@@ -7,8 +7,10 @@ import com.back2basics.board.file.model.File;
 import com.back2basics.board.file.port.out.FileSavePort;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FileSaveAdapter implements FileSavePort {
@@ -18,6 +20,7 @@ public class FileSaveAdapter implements FileSavePort {
 
     @Override
     public void saveAll(List<File> files, Long postId) {
+        log.info("=== FileSaveAdapter 내부 {}", files.get(0).getFileUrl());
         List<FileEntity> entities = files.stream()
             .map(file -> fileMapper.toEntity(file, postId))
             .toList();

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/S3PresignedUrlAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/S3PresignedUrlAdapter.java
@@ -1,0 +1,17 @@
+package com.back2basics.adapter.persistence.board.file.adapter;
+
+import com.back2basics.board.file.port.out.FilePresignedUrlPort;
+import com.back2basics.infra.s3.S3Util;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class S3PresignedUrlAdapter implements FilePresignedUrlPort{
+    private final S3Util s3Util;
+
+    @Override
+    public String generateDownloadUrl(String fileKey) {
+        return s3Util.generatePresignedDownloadUrl(fileKey);
+    }
+}

--- a/module-infra/src/main/java/com/back2basics/config/S3PresignerConfig.java
+++ b/module-infra/src/main/java/com/back2basics/config/S3PresignerConfig.java
@@ -1,0 +1,34 @@
+package com.back2basics.config;
+
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3PresignerConfig {
+
+    @Value("${cloudflare.r2.endpoint}")
+    private String endpoint;
+
+    @Value("${cloudflare.r2.access-key}")
+    private String accessKey;
+
+    @Value("${cloudflare.r2.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+            .endpointOverride(URI.create(endpoint))
+            .region(Region.of("auto"))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)
+            ))
+            .build();
+    }
+}


### PR DESCRIPTION
## 📌 개요
첨부파일 업로드/다운로드를 presignedURL 방식으로 개선

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
첨부파일 업로드/다운로드를 presignedURL 방식으로 개선
현재 s3Utils 를 통해 직접 서버에서 s3 storage로 파일을 업로드 하는 방식에서 presignedURL 방식으로 변경
파일 다운로드도 마찬가지로 서버에서 다운 후 프론트에 내려주는 방식이므로 presignedURL 방식으로 변경

## 🔍 관련 이슈
<!-- 예: Close #12 -->
- Close #508 
- See also #

## 🧪 테스트 결과
<!-- 테스트 방법 및 결과 요약 -->
<!-- - Postman으로 회원가입 API 정상 동작 확인 -->

## 👀 리뷰어에게 요청사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분 -->
<!-- - 이메일 형식 검증 로직에 문제 없는지 확인 부탁드립니다. -->

## 📎 기타 참고 사항
<!-- 추가적인 설명이나 참고 자료 (디자인 링크, API 문서 등) -->
<!-- - [API 문서](링크) -->
