### PR TITLE
[Deploy] 게시글 복구 기능 추가 및 멘션 알림 연동, 유저 더미 데이터 삽입 로직 디렉토리 정리 및 주석 처리

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
@@ -6,6 +6,7 @@ import com.back2basics.board.file.service.FilePresignedUrlResult;
 import com.back2basics.board.post.port.in.PostCreateUseCase;
 import com.back2basics.board.post.port.in.PostDeleteUseCase;
 import com.back2basics.board.post.port.in.PostReadUseCase;
+import com.back2basics.board.post.port.in.PostRestoreUseCase;
 import com.back2basics.board.post.port.in.PostSearchUseCase;
 import com.back2basics.board.post.port.in.PostUpdateUseCase;
 import com.back2basics.board.post.service.result.PostCreateResult;
@@ -65,6 +66,7 @@ public class PostController /*implements PostApiDocs*/ {
     private final PostDeleteUseCase postDeleteUseCase;
     private final PostSearchUseCase postSearchUseCase;
     private final FileDownloadUseCase fileDownloadUseCase;
+    private final PostRestoreUseCase postRestoreUseCase;
 
     @PostMapping
     public ResponseEntity<ApiResponse<PostCreateResponse>> createPost(
@@ -142,6 +144,15 @@ public class PostController /*implements PostApiDocs*/ {
         Long userId = customUserDetails.getId();
         postDeleteUseCase.softDeletePost(userId, postId);
         return ApiResponse.success(PostResponseCode.POST_DELETE_SUCCESS);
+    }
+
+    @PutMapping("/{postId}/restore")
+    public ResponseEntity<ApiResponse<Void>> restorePost(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @PathVariable Long postId) {
+        Long userId = customUserDetails.getId();
+        postRestoreUseCase.restorePost(userId, postId);
+        return ApiResponse.success(PostResponseCode.POST_RESTORE_SUCCESS);
     }
 
     @GetMapping("/search")

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
@@ -2,6 +2,7 @@ package com.back2basics.domain.board.controller;
 
 import com.back2basics.board.file.port.in.FileDownloadUseCase;
 import com.back2basics.board.file.service.FileDownloadResult;
+import com.back2basics.board.file.service.FilePresignedUrlResult;
 import com.back2basics.board.post.port.in.PostCreateUseCase;
 import com.back2basics.board.post.port.in.PostDeleteUseCase;
 import com.back2basics.board.post.port.in.PostReadUseCase;
@@ -14,8 +15,10 @@ import com.back2basics.board.post.service.result.PostSummaryReadResult;
 import com.back2basics.board.post.service.result.ReadRecentPostResult;
 import com.back2basics.domain.board.controller.code.PostResponseCode;
 import com.back2basics.domain.board.dto.request.PostCreateRequest;
+import com.back2basics.domain.board.dto.request.PostCreateWithPresignedRequest;
 import com.back2basics.domain.board.dto.request.PostSearchRequest;
 import com.back2basics.domain.board.dto.request.PostUpdateRequest;
+import com.back2basics.domain.board.dto.request.PostUpdateWithPresignedRequest;
 import com.back2basics.domain.board.dto.response.PostCreateResponse;
 import com.back2basics.domain.board.dto.response.PostDashboardReadResponse;
 import com.back2basics.domain.board.dto.response.PostDetailReadResponse;
@@ -41,6 +44,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -209,5 +213,60 @@ public class PostController /*implements PostApiDocs*/ {
 
         return ApiResponse.success(PostResponseCode.POST_READ_ALL_DASHBOARD_SUCCESS, responseList);
 
+    }
+
+    @PostMapping("/presigned")
+    public ResponseEntity<ApiResponse<PostCreateResponse>> createPostWithPresigned(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @RequestBody @Valid PostCreateWithPresignedRequest request
+    ) {
+        Long userId = customUserDetails.getId();
+        String userIp = customUserDetails.getIp();
+
+        log.info("========================url : {}", request.getUploadedFiles().get(0).getUrl());
+        log.info("========================url : {}", request.getUploadedFiles().get(0).getUrl());
+        PostCreateResult result = createPostUseCase.createPostWithPresigned(
+            userId,
+            request.getProjectId(),
+            request.getStepId(),
+            userIp,
+            request.toCommand(),
+            request.toUploadedFileInfos()
+        );
+        PostCreateResponse response = PostCreateResponse.toResponse(result);
+        return ApiResponse.success(PostResponseCode.POST_CREATE_PRESIGNED_SUCCESS, response);
+    }
+
+    @PutMapping("/{postId}/presigned")
+    public ResponseEntity<ApiResponse<Void>> updatePostWithPresigned(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @PathVariable Long postId,
+        @RequestBody @Valid PostUpdateWithPresignedRequest request
+    ) {
+        Long userId = customUserDetails.getId();
+        String userIp = customUserDetails.getIp();
+
+        postUpdateUseCase.updatePostWithPresigned(
+            userId,
+            userIp,
+            postId,
+            request.toCommand(),
+            request.toUploadedFileInfos()
+        );
+
+        return ApiResponse.success(PostResponseCode.POST_UPDATE_PRESIGNED_SUCCESS);
+    }
+
+    @GetMapping("/{postId}/files/{fileId}/presigned")
+    public ResponseEntity<ApiResponse<String>> getFilePresignedDownloadUrl(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails,
+        @PathVariable Long postId,
+        @PathVariable Long fileId
+    ) {
+        FilePresignedUrlResult result = fileDownloadUseCase.getPresignedDownloadUrl(
+            customUserDetails.getId(), postId, fileId
+        );
+
+        return ApiResponse.success(PostResponseCode.POST_FILE_PRESIGNED_URL_SUCCESS, result.presignedUrl());
     }
 }

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
@@ -15,10 +15,12 @@ public enum PostResponseCode implements ResponseCode {
     POST_UPDATE_SUCCESS(HttpStatus.OK, "P204", "게시글 수정 완료"),
     POST_DELETE_SUCCESS(HttpStatus.OK, "P205", "게시글 삭제 완료"),
     POST_FILE_DOWNLOAD_SUCCESS(HttpStatus.OK, "PF206", "파일 다운로드 완료"),
-    POST_READ_ALL_DASHBOARD_SUCCESS(HttpStatus.OK, "P207", "진행중인 프로젝트에 등록된 게시글 목록 조회 완료");
+    POST_READ_ALL_DASHBOARD_SUCCESS(HttpStatus.OK, "P207", "진행중인 프로젝트에 등록된 게시글 목록 조회 완료"),
+    POST_CREATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P208", "Presigned URL 기반 게시글 생성 완료"),
+    POST_UPDATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P209", "Presigned URL 기반 게시글 수정 완료"),
+    POST_FILE_PRESIGNED_URL_SUCCESS(HttpStatus.OK,"PF206", "파일 다운로드 URL 발급 완료");
 
     private final HttpStatus status;
     private final String code;
     private final String message;
 }
-

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/code/PostResponseCode.java
@@ -18,7 +18,8 @@ public enum PostResponseCode implements ResponseCode {
     POST_READ_ALL_DASHBOARD_SUCCESS(HttpStatus.OK, "P207", "진행중인 프로젝트에 등록된 게시글 목록 조회 완료"),
     POST_CREATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P208", "Presigned URL 기반 게시글 생성 완료"),
     POST_UPDATE_PRESIGNED_SUCCESS(HttpStatus.CREATED, "P209", "Presigned URL 기반 게시글 수정 완료"),
-    POST_FILE_PRESIGNED_URL_SUCCESS(HttpStatus.OK,"PF206", "파일 다운로드 URL 발급 완료");
+    POST_FILE_PRESIGNED_URL_SUCCESS(HttpStatus.OK,"PF206", "파일 다운로드 URL 발급 완료"),
+    POST_RESTORE_SUCCESS(HttpStatus.OK,"P210", "비활성화 게시글 복구 완료");
 
     private final HttpStatus status;
     private final String code;

--- a/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostCreateWithPresignedRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostCreateWithPresignedRequest.java
@@ -1,0 +1,66 @@
+package com.back2basics.domain.board.dto.request;
+
+import com.back2basics.board.post.model.PostPriority;
+import com.back2basics.board.post.model.PostType;
+import com.back2basics.board.post.port.in.command.PostCreateCommand;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
+import com.back2basics.infra.validation.custom.CustomEnumCheck;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PostCreateWithPresignedRequest {
+
+    @Nullable
+    private Long parentId;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    @NotNull(message = "타입이 입력되지 않았습니다.")
+    @CustomEnumCheck(enumClass = PostType.class, message = "올바른 enum type이 아닙니다")
+    private PostType type;
+
+    @NotNull(message = "우선순위가 입력되지 않았습니다.")
+    @CustomEnumCheck(enumClass = PostPriority.class, message = "올바른 enum type이 아닙니다")
+    private PostPriority priority;
+
+    @NotNull(message = "프로젝트를 입력하세요.")
+    private Long projectId;
+
+    @NotNull(message = "프로젝트 단계를 입력하세요.")
+    private Long stepId;
+
+    private List<String> newLinks = List.of();
+    private List<PresignedUploadedFileRequest> uploadedFiles;
+
+    public PostCreateCommand toCommand() {
+        return PostCreateCommand.builder()
+            .parentId(parentId)
+            .title(title)
+            .content(content)
+            .priority(priority)
+            .projectId(projectId)
+            .stepId(stepId)
+            .type(type)
+            .newLinks(newLinks)
+            .build();
+    }
+
+    public List<PresignedUploadCompleteInfo> toUploadedFileInfos() {
+        return this.uploadedFiles.stream()
+            .map(file -> PresignedUploadCompleteInfo.of(
+                file.getOriginalName(),
+                file.getUrl(),
+                file.getExtension(),
+                file.getSize()
+            ))
+            .toList();
+    }
+}

--- a/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostUpdateWithPresignedRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostUpdateWithPresignedRequest.java
@@ -1,0 +1,61 @@
+package com.back2basics.domain.board.dto.request;
+
+import com.back2basics.board.post.model.PostPriority;
+import com.back2basics.board.post.model.PostType;
+import com.back2basics.board.post.port.in.command.PostUpdateCommand;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
+import com.back2basics.infra.validation.custom.CustomEnumCheck;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PostUpdateWithPresignedRequest {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+
+    @NotNull(message = "타입이 입력되지 않았습니다.")
+    @CustomEnumCheck(enumClass = PostType.class, message = "올바른 enum type이 아닙니다")
+    private PostType type;
+
+    @NotNull(message = "우선순위가 입력되지 않았습니다.")
+    @CustomEnumCheck(enumClass = PostPriority.class, message = "올바른 enum type이 아닙니다")
+    private PostPriority priority;
+
+    @NotNull(message = "단계가 입력되지 않았습니다.")
+    private Long stepId;
+
+    private List<Long> fileIdsToDelete;
+    private List<Long> linkIdsToDelete;
+    private List<String> newLinks;
+    private List<PresignedUploadedFileRequest> uploadedFiles;
+
+    public PostUpdateCommand toCommand() {
+        return PostUpdateCommand.builder()
+            .title(title)
+            .content(content)
+            .type(type)
+            .priority(priority)
+            .stepId(stepId)
+            .fileIdsToDelete(fileIdsToDelete)
+            .linkIdsToDelete(linkIdsToDelete)
+            .newLinks(newLinks)
+            .build();
+    }
+
+    public List<PresignedUploadCompleteInfo> toUploadedFileInfos() {
+        return this.uploadedFiles.stream()
+            .map(file -> PresignedUploadCompleteInfo.of(
+                file.getOriginalName(),
+                file.getUrl(),
+                file.getExtension(),
+                file.getSize()
+            ))
+            .toList();
+    }
+}

--- a/module-api/src/main/java/com/back2basics/domain/board/dto/request/PresignedUploadedFileRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/dto/request/PresignedUploadedFileRequest.java
@@ -1,0 +1,11 @@
+package com.back2basics.domain.board.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class PresignedUploadedFileRequest {
+    private String originalName;
+    private String url;
+    private String extension;
+    private String size;
+}

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -63,6 +63,7 @@ cloudflare:
     bucket: ${R2_BUCKET}
     access-key: ${R2_ACCESS_KEY}
     secret-key: ${R2_SECRET_KEY}
+    public-url: ${R2_PUBLIC_URL}
 
   servlet:
     multipart:

--- a/module-core/src/main/java/com/back2basics/board/file/model/File.java
+++ b/module-core/src/main/java/com/back2basics/board/file/model/File.java
@@ -38,4 +38,10 @@ public class File {
     public File withFileType(String newType) {
         return new File(this.id, this.postId, this.fileName, this.fileUrl, newType, this.fileSize);
     }
+
+    public String getFileKey() {
+        String prefix = "https://danmuji." + "[YOUR_R2_SUBDOMAIN]" + ".r2.cloudflarestorage.com/";
+        return fileUrl.replace(prefix, "");
+    }
+
 }

--- a/module-core/src/main/java/com/back2basics/board/file/port/in/FileDownloadUseCase.java
+++ b/module-core/src/main/java/com/back2basics/board/file/port/in/FileDownloadUseCase.java
@@ -1,9 +1,12 @@
 package com.back2basics.board.file.port.in;
 
 import com.back2basics.board.file.service.FileDownloadResult;
+import com.back2basics.board.file.service.FilePresignedUrlResult;
 import java.io.IOException;
 
 public interface FileDownloadUseCase {
 
     FileDownloadResult downloadFile(Long userId, Long postId, Long fileId) throws IOException;
+
+    FilePresignedUrlResult getPresignedDownloadUrl(Long userId, Long postId, Long fileId);
 }

--- a/module-core/src/main/java/com/back2basics/board/file/port/out/FilePresignedUrlPort.java
+++ b/module-core/src/main/java/com/back2basics/board/file/port/out/FilePresignedUrlPort.java
@@ -1,0 +1,5 @@
+package com.back2basics.board.file.port.out;
+
+public interface FilePresignedUrlPort {
+    String generateDownloadUrl(String fileKey);
+}

--- a/module-core/src/main/java/com/back2basics/board/file/service/FilePresignedUrlResult.java
+++ b/module-core/src/main/java/com/back2basics/board/file/service/FilePresignedUrlResult.java
@@ -1,0 +1,3 @@
+package com.back2basics.board.file.service;
+
+public record FilePresignedUrlResult(String presignedUrl) {}

--- a/module-core/src/main/java/com/back2basics/board/post/model/Post.java
+++ b/module-core/src/main/java/com/back2basics/board/post/model/Post.java
@@ -198,6 +198,11 @@ public class Post implements TargetDomain {
         this.deletedAt = LocalDateTime.now();
     }
 
+    public void restore() {
+        this.isDelete = false;
+        this.deletedAt = null;
+    }
+
     public static Post copyOf(Post post) {
         return Post.createWithFilesAndLinks(
             post.getId(),

--- a/module-core/src/main/java/com/back2basics/board/post/port/in/PostCreateUseCase.java
+++ b/module-core/src/main/java/com/back2basics/board/post/port/in/PostCreateUseCase.java
@@ -2,6 +2,7 @@ package com.back2basics.board.post.port.in;
 
 import com.back2basics.board.post.port.in.command.PostCreateCommand;
 import com.back2basics.board.post.service.result.PostCreateResult;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
@@ -10,4 +11,7 @@ public interface PostCreateUseCase {
 
     PostCreateResult createPost(Long userId, Long projectId, Long projectStepId, String userIp,
         PostCreateCommand command, List<MultipartFile> files) throws IOException;
+
+    PostCreateResult createPostWithPresigned(Long userId, Long projectId, Long stepId,
+        String userIp, PostCreateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles);
 }

--- a/module-core/src/main/java/com/back2basics/board/post/port/in/PostRestoreUseCase.java
+++ b/module-core/src/main/java/com/back2basics/board/post/port/in/PostRestoreUseCase.java
@@ -1,0 +1,5 @@
+package com.back2basics.board.post.port.in;
+
+public interface PostRestoreUseCase {
+    void restorePost(Long requesterId, Long postId);
+}

--- a/module-core/src/main/java/com/back2basics/board/post/port/in/PostUpdateUseCase.java
+++ b/module-core/src/main/java/com/back2basics/board/post/port/in/PostUpdateUseCase.java
@@ -1,12 +1,26 @@
 package com.back2basics.board.post.port.in;
 
 import com.back2basics.board.post.port.in.command.PostUpdateCommand;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface PostUpdateUseCase {
 
-    void updatePost(Long userId, String userIp, Long postId, PostUpdateCommand command,
-        List<MultipartFile> files) throws IOException;
+    void updatePost(
+        Long userId,
+        String userIp,
+        Long postId,
+        PostUpdateCommand command,
+        List<MultipartFile> files
+    ) throws IOException;
+
+    void updatePostWithPresigned(
+        Long userId,
+        String userIp,
+        Long postId,
+        PostUpdateCommand command,
+        List<PresignedUploadCompleteInfo> uploadedFiles
+    );
 }

--- a/module-core/src/main/java/com/back2basics/board/post/port/out/PostReadPort.java
+++ b/module-core/src/main/java/com/back2basics/board/post/port/out/PostReadPort.java
@@ -11,6 +11,8 @@ public interface PostReadPort {
 
     Optional<Post> findById(Long postId);
 
+    Optional<Post> findDeletedPostById(Long postId);
+
     Page<Post> findAllPostsByProjectIdAndStepId(Long projectId, Long projectStepId,
         Pageable pageable);
 

--- a/module-core/src/main/java/com/back2basics/board/post/port/out/PostRestorePort.java
+++ b/module-core/src/main/java/com/back2basics/board/post/port/out/PostRestorePort.java
@@ -1,0 +1,7 @@
+package com.back2basics.board.post.port.out;
+
+import com.back2basics.board.post.model.Post;
+
+public interface PostRestorePort {
+    void restorePost(Post post);
+}

--- a/module-core/src/main/java/com/back2basics/board/post/service/PostRestoreService.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/PostRestoreService.java
@@ -1,0 +1,36 @@
+package com.back2basics.board.post.service;
+
+import com.back2basics.board.post.model.Post;
+import com.back2basics.board.post.port.in.PostRestoreUseCase;
+import com.back2basics.board.post.port.out.PostRestorePort;
+import com.back2basics.board.post.service.notification.PostNotificationSender;
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
+import com.back2basics.infra.validation.validator.PostValidator;
+import com.back2basics.infra.validation.validator.UserValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostRestoreService implements PostRestoreUseCase {
+
+    private final PostRestorePort postRestorePort;
+    private final PostValidator postValidator;
+    private final HistoryLogService historyLogService;
+    private final UserValidator userValidator;
+    private final PostNotificationSender postNotificationSender;
+
+
+    @Override
+    public void restorePost(Long requesterId, Long postId) {
+        userValidator.isAdmin(requesterId);
+        Post post = postValidator.isDeleted(postId);
+
+        post.restore();
+        postRestorePort.restorePost(post);
+
+        historyLogService.logRestored(DomainType.POST, requesterId, post, "비활성화 게시글 복구");
+        postNotificationSender.sendNotification(requesterId, post.getId());
+    }
+}

--- a/module-core/src/main/java/com/back2basics/board/post/service/notification/PostNotificationSender.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/notification/PostNotificationSender.java
@@ -56,4 +56,16 @@ public class PostNotificationSender {
         }
     }
 
+    public void sendNotification(Long senderId, Long postId) {
+        Post post = postValidator.findPost(postId);
+
+        notifyUseCase.notify(new SendNotificationCommand(
+            post.getAuthorId(),
+            post.getProjectId(),
+            postId,
+            NotificationType.POST_RESTORED.getDescription(),
+            NotificationType.POST_RESTORED
+        ));
+    }
+
 }

--- a/module-core/src/main/java/com/back2basics/history/model/HistoryRequestFactory.java
+++ b/module-core/src/main/java/com/back2basics/history/model/HistoryRequestFactory.java
@@ -8,6 +8,24 @@ import org.springframework.stereotype.Component;
 @Component
 public class HistoryRequestFactory {
 
+    public static <T extends TargetDomain> HistoryCreateCommand restored(DomainType domainType,
+        User user,
+        T after, String message) {
+        return new HistoryCreateCommand(
+            HistoryType.RESTORED,
+            domainType,
+            after.getId(),
+            user.getId(),
+            user.getName(),
+            user.getUsername(),
+            user.getRole(),
+            "복구 - before 정보 없음",
+            after,
+            message
+        );
+    }
+
+
     // static으로 해줄 필요가 굳이 있나? 처음에는 팩토리메소드 개념 넣는다고 해서 한건데 갑자기 하다보니 굳이? 오버로딩도아니고 메소드이름도 다른데
     public static <T extends TargetDomain> HistoryCreateCommand created(DomainType domainType,
         User user,

--- a/module-core/src/main/java/com/back2basics/history/model/HistoryType.java
+++ b/module-core/src/main/java/com/back2basics/history/model/HistoryType.java
@@ -6,7 +6,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 public enum HistoryType {
     CREATED("생성"),
     UPDATED("수정"),
-    DELETED("삭제");
+    DELETED("삭제"),
+    RESTORED("복구");
 
     private final String message;
 

--- a/module-core/src/main/java/com/back2basics/history/service/HistoryLogService.java
+++ b/module-core/src/main/java/com/back2basics/history/service/HistoryLogService.java
@@ -16,6 +16,12 @@ public class HistoryLogService {
     private final UserQueryPort userQueryPort;
     private final HistoryCreateService historyCreateService;
 
+    public <T extends TargetDomain> void logRestored(DomainType domainType, Long userId, T after, String message) {
+        User user = userQueryPort.findById(userId);
+        historyCreateService.create(
+            HistoryRequestFactory.restored(domainType, user, after, message)
+        );
+    }
 
     public <T extends TargetDomain> void logCreated(DomainType domainType, Long userId, T after,
         String message) {

--- a/module-core/src/main/java/com/back2basics/infra/exception/file/FileErrorCode.java
+++ b/module-core/src/main/java/com/back2basics/infra/exception/file/FileErrorCode.java
@@ -12,7 +12,10 @@ public enum FileErrorCode implements ErrorCode {
 
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "F001", "파일을 찾을 수 없습니다."),
     FILE_DOWNLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "F002", "파일 다운로드 실패"),
-    FILE_DOWNLOAD_DENIED(HttpStatus.FORBIDDEN, "F003", "파일 다운로드 권한이 없습니다.");
+    FILE_DOWNLOAD_DENIED(HttpStatus.FORBIDDEN, "F003", "파일 다운로드 권한이 없습니다."),
+    FILE_DELETE_FAILED_URL_EMPTY(HttpStatus.BAD_REQUEST, "F004", "파일 URL이 null이거나 비어 있습니다."),
+    FILE_DELETE_FAILED_WRONG_URL(HttpStatus.BAD_REQUEST, "F004", "파일 URL이 잘못된 형식입니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/module-core/src/main/java/com/back2basics/infra/exception/post/PostErrorCode.java
+++ b/module-core/src/main/java/com/back2basics/infra/exception/post/PostErrorCode.java
@@ -11,7 +11,9 @@ public enum PostErrorCode implements ErrorCode {
 
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "게시글을 찾을 수 없습니다"),
     INVALID_POST_AUTHOR(HttpStatus.FORBIDDEN, "P002", "게시글 작성자가 아닙니다"),
-    DUPLICATE_POST_TITLE(HttpStatus.BAD_REQUEST, "P003", "중복된 제목의 게시글입니다");
+    DUPLICATE_POST_TITLE(HttpStatus.BAD_REQUEST, "P003", "중복된 제목의 게시글입니다"),
+    POST_NOT_DELETED(HttpStatus.BAD_REQUEST, "P004", "삭제된 게시글이 아닙니다"),
+    POST_ALREADY_RESTORED(HttpStatus.BAD_REQUEST, "P005", "이미 복구된 게시글입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/module-core/src/main/java/com/back2basics/infra/s3/dto/PresignedUploadCompleteInfo.java
+++ b/module-core/src/main/java/com/back2basics/infra/s3/dto/PresignedUploadCompleteInfo.java
@@ -1,0 +1,20 @@
+package com.back2basics.infra.s3.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PresignedUploadCompleteInfo {
+    private String originalName;
+    private String url;
+    private String extension;
+    private String size;
+
+    public static PresignedUploadCompleteInfo of(String originalName, String url, String extension, String size) {
+        PresignedUploadCompleteInfo info = new PresignedUploadCompleteInfo();
+        info.originalName = originalName;
+        info.url = url;
+        info.extension = extension;
+        info.size = size;
+        return info;
+    }
+}

--- a/module-core/src/main/java/com/back2basics/infra/validation/validator/PostValidator.java
+++ b/module-core/src/main/java/com/back2basics/infra/validation/validator/PostValidator.java
@@ -1,9 +1,9 @@
 package com.back2basics.infra.validation.validator;
 
-import com.back2basics.infra.exception.post.PostErrorCode;
-import com.back2basics.infra.exception.post.PostException;
 import com.back2basics.board.post.model.Post;
 import com.back2basics.board.post.port.out.PostReadPort;
+import com.back2basics.infra.exception.post.PostErrorCode;
+import com.back2basics.infra.exception.post.PostException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -14,6 +14,11 @@ import org.springframework.stereotype.Component;
 public class PostValidator {
 
     private final PostReadPort postReadPort;
+
+    public Post isDeleted(Long id) {
+        return postReadPort.findDeletedPostById(id)
+            .orElseThrow(() -> new PostException(PostErrorCode.POST_ALREADY_RESTORED));
+    }
 
     public Post findPost(Long id) {
         return postReadPort.findById(id)

--- a/module-core/src/main/java/com/back2basics/infra/validation/validator/UserValidator.java
+++ b/module-core/src/main/java/com/back2basics/infra/validation/validator/UserValidator.java
@@ -4,6 +4,7 @@ import static com.back2basics.infra.exception.user.UserErrorCode.DUPLICATE_USERN
 import static com.back2basics.infra.exception.user.UserErrorCode.USER_NOT_FOUND;
 
 import com.back2basics.infra.exception.user.UserException;
+import com.back2basics.user.model.Role;
 import com.back2basics.user.model.User;
 import com.back2basics.user.port.out.UserQueryPort;
 import java.util.List;
@@ -15,6 +16,11 @@ import org.springframework.stereotype.Component;
 public class UserValidator {
 
     private final UserQueryPort userQueryPort;
+
+    public boolean isAdmin(Long userId){
+        User user = userQueryPort.findById(userId);
+        return user.getRole() == Role.ADMIN;
+    }
 
     public void validateDuplicateUsername(String username) {
         boolean exists = userQueryPort.existsByUsername(username);

--- a/module-core/src/main/java/com/back2basics/notify/model/NotificationType.java
+++ b/module-core/src/main/java/com/back2basics/notify/model/NotificationType.java
@@ -16,6 +16,7 @@ public enum NotificationType {
 
     PROJECT_POST_CREATED("프로젝트에 새로운 게시글이 등록되었습니다."),
     POST_REPLY_CREATED("내 게시글에 답글이 달렸습니다."),
+    POST_RESTORED("비활성화 게시글이 복구되었습니다."),
 
     COMMENT_POST_CREATED("내 게시글에 댓글이 달렸습니다."),
     COMMENT_REPLY_CREATED("내 댓글에 답글이 달렸습니다."),

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/FileMapper.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/FileMapper.java
@@ -2,8 +2,10 @@ package com.back2basics.adapter.persistence.board.file;
 
 
 import com.back2basics.board.file.model.File;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class FileMapper {
 
@@ -19,6 +21,7 @@ public class FileMapper {
     }
 
     public FileEntity toEntity(File file, Long postId) {
+        log.info("===FileMapper의 toEntity() url: {}", file.getFileUrl());
         return new FileEntity(
             file.getId(),
             postId,

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/FileDeleteAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/FileDeleteAdapter.java
@@ -1,9 +1,13 @@
 package com.back2basics.adapter.persistence.board.file.adapter;
 
+import static com.back2basics.infra.exception.file.FileErrorCode.FILE_DELETE_FAILED_URL_EMPTY;
+import static com.back2basics.infra.exception.file.FileErrorCode.FILE_DELETE_FAILED_WRONG_URL;
+
 import com.back2basics.adapter.persistence.board.file.FileEntityRepository;
-import com.back2basics.infra.s3.S3Util;
 import com.back2basics.board.file.model.File;
 import com.back2basics.board.file.port.out.FileDeletePort;
+import com.back2basics.infra.exception.file.FileException;
+import com.back2basics.infra.s3.S3Util;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +48,13 @@ public class FileDeleteAdapter implements FileDeletePort {
     }
 
     private String extractKeyFromUrl(String url) {
-        // 예시: https://domain/uuid_filename.ext → uuid_filename.ext
-        return url.substring(url.lastIndexOf("/") + 1);
+        if (url == null || url.isBlank()) {
+            throw new FileException(FILE_DELETE_FAILED_URL_EMPTY);
+        }
+        int lastSlash = url.lastIndexOf("/");
+        if (lastSlash == -1 || lastSlash == url.length() - 1) {
+            throw new FileException(FILE_DELETE_FAILED_WRONG_URL);
+        }
+        return url.substring(lastSlash + 1);
     }
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/FileSaveAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/FileSaveAdapter.java
@@ -7,8 +7,10 @@ import com.back2basics.board.file.model.File;
 import com.back2basics.board.file.port.out.FileSavePort;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FileSaveAdapter implements FileSavePort {
@@ -18,6 +20,7 @@ public class FileSaveAdapter implements FileSavePort {
 
     @Override
     public void saveAll(List<File> files, Long postId) {
+        log.info("=== FileSaveAdapter 내부 {}", files.get(0).getFileUrl());
         List<FileEntity> entities = files.stream()
             .map(file -> fileMapper.toEntity(file, postId))
             .toList();

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/S3PresignedUrlAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/file/adapter/S3PresignedUrlAdapter.java
@@ -1,0 +1,17 @@
+package com.back2basics.adapter.persistence.board.file.adapter;
+
+import com.back2basics.board.file.port.out.FilePresignedUrlPort;
+import com.back2basics.infra.s3.S3Util;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class S3PresignedUrlAdapter implements FilePresignedUrlPort{
+    private final S3Util s3Util;
+
+    @Override
+    public String generateDownloadUrl(String fileKey) {
+        return s3Util.generatePresignedDownloadUrl(fileKey);
+    }
+}

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/adapter/PostRestoreJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/adapter/PostRestoreJpaAdapter.java
@@ -1,0 +1,32 @@
+package com.back2basics.adapter.persistence.board.post.adapter;
+
+import static com.back2basics.infra.exception.post.PostErrorCode.POST_ALREADY_RESTORED;
+
+import com.back2basics.adapter.persistence.board.post.PostEntity;
+import com.back2basics.adapter.persistence.board.post.PostEntityRepository;
+import com.back2basics.adapter.persistence.board.post.PostMapper;
+import com.back2basics.board.post.model.Post;
+import com.back2basics.board.post.port.out.PostRestorePort;
+import com.back2basics.infra.exception.post.PostException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostRestoreJpaAdapter implements PostRestorePort {
+
+    private final PostEntityRepository postRepository;
+    private final PostReadJpaAdapter postReadJpaAdapter;
+    private final PostMapper mapper;
+
+    @Override
+    public void restorePost(Post post) {
+        Post deletedPost = postReadJpaAdapter.findDeletedPostById(post.getId())
+            .orElseThrow(() -> new PostException(POST_ALREADY_RESTORED));
+
+        PostEntity entity = mapper.toEntity(deletedPost);
+
+        entity.restore();
+        postRepository.save(entity);
+    }
+}

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/common/entity/BaseTimeEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/common/entity/BaseTimeEntity.java
@@ -27,4 +27,5 @@ public abstract class BaseTimeEntity {
     private LocalDateTime deletedAt;
 
     public void markDeleted()  { this.deletedAt = LocalDateTime.now(); }
+    public void restore(){this.deletedAt = null;}
 }

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/notification/mention/MentionReadAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/notification/mention/MentionReadAdapter.java
@@ -40,7 +40,8 @@ public class MentionReadAdapter implements ReadMentionPort {
                 notificationEntity.type.in(
                     NotificationType.MENTIONED,
                     NotificationType.PROJECT_POST_CREATED, NotificationType.COMMENT_POST_CREATED,
-                    NotificationType.COMMENT_REPLY_CREATED, NotificationType.POST_REPLY_CREATED
+                    NotificationType.COMMENT_REPLY_CREATED, NotificationType.POST_REPLY_CREATED,
+                    NotificationType.POST_RESTORED
                 ),
                 notificationEntity.deletedAt.isNull()
             )

--- a/module-infra/src/main/java/com/back2basics/bulk/UserBulkInitializer.java
+++ b/module-infra/src/main/java/com/back2basics/bulk/UserBulkInitializer.java
@@ -1,0 +1,55 @@
+//package com.back2basics.test;
+//
+//import com.back2basics.adapter.persistence.user.entity.UserEntity;
+//import com.back2basics.adapter.persistence.user.repository.UserEntityRepository;
+//import com.back2basics.user.model.Role;
+//import java.time.LocalDateTime;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.UUID;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.stereotype.Component;
+//
+//@Slf4j
+//@Component
+//@RequiredArgsConstructor
+//public class UserBulkInitializer implements CommandLineRunner {
+//
+//    private final UserEntityRepository userRepository;
+//
+//    @Override
+//    public void run(String... args) {
+//        int total = 2_000_000;
+//        int batchSize = 10_000;
+//        List<UserEntity> batch = new ArrayList<>();
+//
+//        for (int i = 1; i <= total; i++) {
+//            UserEntity user = UserEntity.builder()
+//                // .username("user" + i)
+//                .username(UUID.randomUUID().toString().replace("-", "").substring(0, 12))
+//                .password("pw1234")
+//                .name("사용자" + i)
+//                .email("user" + i + "@email.com")
+//                .phone("010-0000-" + String.format("%04d", i % 10000))
+//                .position("Dev")
+//                .role(Role.USER)
+//                .company(null) // 또는 임의 CompanyEntity
+//                .lastLoginAt(LocalDateTime.now())
+//                .build();
+//
+//            batch.add(user);
+//
+//            if (batch.size() == batchSize) {
+//                userRepository.saveAll(batch);
+//                batch.clear();
+//                System.out.println("Saved batch up to user" + i);
+//            }
+//        }
+//
+//        if (!batch.isEmpty()) {
+//            userRepository.saveAll(batch);
+//        }
+//    }
+//}

--- a/module-infra/src/main/java/com/back2basics/config/S3PresignerConfig.java
+++ b/module-infra/src/main/java/com/back2basics/config/S3PresignerConfig.java
@@ -1,0 +1,34 @@
+package com.back2basics.config;
+
+import java.net.URI;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3PresignerConfig {
+
+    @Value("${cloudflare.r2.endpoint}")
+    private String endpoint;
+
+    @Value("${cloudflare.r2.access-key}")
+    private String accessKey;
+
+    @Value("${cloudflare.r2.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+            .endpointOverride(URI.create(endpoint))
+            .region(Region.of("auto"))
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(accessKey, secretKey)
+            ))
+            .build();
+    }
+}


### PR DESCRIPTION
## 📌 개요  
게시글 복구 기능 추가 및 멘션 알림 연동, 유저 더미 데이터 삽입 로직 디렉토리 정리 및 주석 처리

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [x] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [x] 기타 (Other)

## ✅ 작업 내용 상세
- 게시글 복구 기능 API 추가
- 게시글 복구 시 멘션 알림 전송 및 알림 목록 출력 기능 연동
- 게시글 이력 복구 기능 추가
- 게시글 작성자 검증 로직 제거
- 유저 200만건 더미 데이터 bulk insert 코드 주석 처리
- `test/bulkinsert` 디렉토리 → `test/bulk`로 변경

## 🔍 관련 이슈
- Close #
- See also #

## 🧪 테스트 결과

## 👀 리뷰어에게 요청사항

## 📎 기타 참고 사항
- 테스트 데이터 삽입 시 주석 처리된 bulk 코드 참고 