### PR TITLE
[Feature] 전화번호 정규식 수정 및 회원 수정 시 id 수정 안되게 함

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/company/dto/request/CreateCompanyRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/company/dto/request/CreateCompanyRequest.java
@@ -26,8 +26,8 @@ public class CreateCompanyRequest {
     private String email;
     @CustomNotBlank(message = "회사 전화번호는 공백일 수 없습니다.")
     @Pattern(
-        regexp = "^\\d{9,11}$",
-        message = "전화번호는 숫자만 포함하여 9~11자리여야 합니다."
+        regexp = "^\\d{8,11}$",
+        message = "전화번호는 숫자만 포함하여 8~11자리여야 합니다."
     )
     private String tel;
 

--- a/module-api/src/main/java/com/back2basics/domain/company/dto/request/UpdateCompanyRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/company/dto/request/UpdateCompanyRequest.java
@@ -26,8 +26,8 @@ public class UpdateCompanyRequest {
     private String email;
     @CustomNotBlank(message = "회사 전화번호는 공백일 수 없습니다.")
     @Pattern(
-        regexp = "^\\d{9,11}$",
-        message = "전화번호는 숫자만 포함하여 9~11자리여야 합니다."
+        regexp = "^\\d{8,11}$",
+        message = "전화번호는 숫자만 포함하여 8~11자리여야 합니다."
     )
     private String tel;
 

--- a/module-api/src/main/java/com/back2basics/domain/user/dto/request/UserCreateRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/user/dto/request/UserCreateRequest.java
@@ -18,8 +18,8 @@ public record UserCreateRequest(@NotEmpty
                                 @Email(message = "유효한 이메일 형식이 아닙니다.") String email,
                                 @NotEmpty(message = "전화번호는 필수입니다.")
                                 @Pattern(
-                                    regexp = "^\\d{9,11}$",
-                                    message = "전화번호는 숫자만 포함하여 9~11자리여야 합니다."
+                                    regexp = "^\\d{8,11}$",
+                                    message = "전화번호는 숫자만 포함하여 8~11자리여야 합니다."
                                 ) String phone,
                                 @Size(max = 50, message = "직책은 최대 50자까지 가능합니다.") String position,
                                 Long companyId) {

--- a/module-api/src/main/java/com/back2basics/domain/user/dto/request/UserUpdateRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/user/dto/request/UserUpdateRequest.java
@@ -6,27 +6,22 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-public record UserUpdateRequest(@NotEmpty
-                                @Pattern(
-                                    regexp = "^[a-zA-Z0-9_]{4,20}$",
-                                    message = "아이디는 영문자, 숫자, 밑줄(_)만 가능하며 4~20자여야 합니다."
-                                ) String username,
-                                @NotEmpty(message = "이름은 필수입니다.")
-                                @Size(min = 2, max = 30, message = "이름은 2자 이상 30자 이하로 입력해주세요.") String name,
+public record UserUpdateRequest(
+    @NotEmpty(message = "이름은 필수입니다.")
+    @Size(min = 2, max = 30, message = "이름은 2자 이상 30자 이하로 입력해주세요.") String name,
 
-                                @NotEmpty(message = "이메일은 필수입니다.")
-                                @Email(message = "유효한 이메일 형식이 아닙니다.") String email,
-                                @NotEmpty(message = "전화번호는 필수입니다.")
-                                @Pattern(
-                                    regexp = "^\\d{9,11}$",
-                                    message = "전화번호는 숫자만 포함하여 10~11자리여야 합니다."
-                                ) String phone,
-                                @Size(max = 50, message = "직책은 최대 50자까지 가능합니다.") String position,
-                                Long companyId) {
+    @NotEmpty(message = "이메일은 필수입니다.")
+    @Email(message = "유효한 이메일 형식이 아닙니다.") String email,
+    @NotEmpty(message = "전화번호는 필수입니다.")
+    @Pattern(
+        regexp = "^\\d{8,11}$",
+        message = "전화번호는 숫자만 포함하여 8~11자리여야 합니다."
+    ) String phone,
+    @Size(max = 50, message = "직책은 최대 50자까지 가능합니다.") String position,
+    Long companyId) {
 
     public UserUpdateCommand toCommand() {
         return UserUpdateCommand.builder()
-            .username(username)
             .name(name)
             .email(email)
             .phone(phone)

--- a/module-core/src/main/java/com/back2basics/user/model/User.java
+++ b/module-core/src/main/java/com/back2basics/user/model/User.java
@@ -57,9 +57,8 @@ public class User implements TargetDomain {
             .build();
     }
 
-    public void updateUser(String username, String name, String email, String phone,
+    public void updateUser(String name, String email, String phone,
         String position, Long companyId) {
-        this.username = username;
         this.name = name;
         this.email = email;
         this.phone = phone;

--- a/module-core/src/main/java/com/back2basics/user/port/in/command/UserUpdateCommand.java
+++ b/module-core/src/main/java/com/back2basics/user/port/in/command/UserUpdateCommand.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserUpdateCommand {
 
-    private String username;
     private String name;
     private String email;
     private String phone;
@@ -16,9 +15,8 @@ public class UserUpdateCommand {
     private Long companyId;
 
     @Builder
-    public UserUpdateCommand(String username, String name, String email,
+    public UserUpdateCommand(String name, String email,
         String phone, String position, Long companyId) {
-        this.username = username;
         this.name = name;
         this.email = email;
         this.phone = phone;

--- a/module-core/src/main/java/com/back2basics/user/service/UpdateUserService.java
+++ b/module-core/src/main/java/com/back2basics/user/service/UpdateUserService.java
@@ -23,7 +23,7 @@ public class UpdateUserService implements UpdateUserUseCase {
     public void update(Long userId, UserUpdateCommand command, Long loggedInUserId) {
         User user = userQueryPort.findById(userId);
         User beforeUser = User.copyOf(user);
-        user.updateUser(command.getUsername(), command.getName(), command.getEmail(),
+        user.updateUser(command.getName(), command.getEmail(),
             command.getPhone(), command.getPosition(), command.getCompanyId());
 
         userCommandPort.save(user);


### PR DESCRIPTION
## 📌 개요
전화번호 정규식 수정 및 회원 수정 시 id 수정 안되게 함

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [X] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
전화번호 정규식 수정 및 회원 수정 시 id 수정 안되게 함
전화번호 9, 11에서 8, 11로 변경(1588-1588의 경우 추가)
회원 수정 dto에서 username삭제(아이디는 변경 불가)

## 🔍 관련 이슈
- Close #562 

## 🧪 테스트 결과
로컬 환경 동작 확인

## 👀 리뷰어에게 요청사항

## 📎 기타 참고 사항
