### PR TITLE
[Task] api 성능 최적화를 위한 쿼리 수정, 인덱스 생성, post리팩토링

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
@@ -259,7 +259,7 @@ public class PostController /*implements PostApiDocs*/ {
         @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @PathVariable Long postId,
         @RequestBody @Valid PostUpdateWithPresignedRequest request
-    ) {
+    ) throws IOException {
         Long userId = customUserDetails.getId();
         String userIp = IpHolder.getIp();
 

--- a/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/controller/PostController.java
@@ -236,7 +236,7 @@ public class PostController /*implements PostApiDocs*/ {
     public ResponseEntity<ApiResponse<PostCreateResponse>> createPostWithPresigned(
         @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @RequestBody @Valid PostCreateWithPresignedRequest request
-    ) {
+    ) throws IOException {
         Long userId = customUserDetails.getId();
         String userIp = IpHolder.getIp();
 

--- a/module-api/src/main/java/com/back2basics/domain/company/controller/CompanyController.java
+++ b/module-api/src/main/java/com/back2basics/domain/company/controller/CompanyController.java
@@ -100,7 +100,7 @@ public class CompanyController /*implements CompanyApiDocs*/ {
         @PageableDefault(
             page = 0,
             size = 10,
-            sort = "createdAt",
+            sort = "id",
             direction = Direction.DESC
         )
         Pageable pageable,
@@ -118,7 +118,7 @@ public class CompanyController /*implements CompanyApiDocs*/ {
         @PageableDefault(
             page = 0,
             size = 10,
-            sort = "createdAt",
+            sort = "id",
             direction = Direction.DESC
         )
         Pageable pageable) {
@@ -154,7 +154,7 @@ public class CompanyController /*implements CompanyApiDocs*/ {
         @PageableDefault(
             page = 0,
             size = 10,
-            sort = "createdAt",
+            sort = "id",
             direction = Direction.DESC
         )
         Pageable pageable) {
@@ -170,7 +170,7 @@ public class CompanyController /*implements CompanyApiDocs*/ {
         @PageableDefault(
             page = 0,
             size = 10,
-            sort = "createdAt",
+            sort = "id",
             direction = Direction.DESC
         )
         Pageable pageable) {

--- a/module-api/src/main/java/com/back2basics/domain/user/controller/AdminController.java
+++ b/module-api/src/main/java/com/back2basics/domain/user/controller/AdminController.java
@@ -155,7 +155,7 @@ public class AdminController {
         @PageableDefault(
             page = 0,
             size = 10,
-            sort = "createdAt",
+            sort = "id",
             direction = Sort.Direction.DESC
         )
         Pageable pageable) {

--- a/module-core/src/main/java/com/back2basics/board/post/port/in/PostCreateUseCase.java
+++ b/module-core/src/main/java/com/back2basics/board/post/port/in/PostCreateUseCase.java
@@ -13,5 +13,6 @@ public interface PostCreateUseCase {
         PostCreateCommand command, List<MultipartFile> files) throws IOException;
 
     PostCreateResult createPostWithPresigned(Long userId, Long projectId, Long stepId,
-        String userIp, PostCreateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles);
+        String userIp, PostCreateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles)
+        throws IOException;
 }

--- a/module-core/src/main/java/com/back2basics/board/post/port/in/PostUpdateUseCase.java
+++ b/module-core/src/main/java/com/back2basics/board/post/port/in/PostUpdateUseCase.java
@@ -22,5 +22,5 @@ public interface PostUpdateUseCase {
         Long postId,
         PostUpdateCommand command,
         List<PresignedUploadCompleteInfo> uploadedFiles
-    );
+    ) throws IOException;
 }

--- a/module-core/src/main/java/com/back2basics/board/post/service/PostCreateService.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/PostCreateService.java
@@ -1,23 +1,10 @@
 package com.back2basics.board.post.service;
 
-import com.back2basics.board.link.service.LinkCreateService;
-import com.back2basics.board.post.model.Post;
 import com.back2basics.board.post.port.in.PostCreateUseCase;
 import com.back2basics.board.post.port.in.command.PostCreateCommand;
-import com.back2basics.board.post.port.out.PostCreatePort;
-import com.back2basics.board.post.service.notification.PostNotificationSender;
 import com.back2basics.board.post.service.result.PostCreateResult;
-import com.back2basics.file.model.ContentType;
-import com.back2basics.file.model.File;
-import com.back2basics.file.port.out.FileSavePort;
-import com.back2basics.file.service.FileUploadService;
-import com.back2basics.history.model.DomainType;
-import com.back2basics.history.service.HistoryLogService;
+import com.back2basics.board.post.service.utils.PostCreateProcessor;
 import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
-import com.back2basics.infra.validator.PostValidator;
-import com.back2basics.infra.validator.ProjectValidator;
-import com.back2basics.infra.validator.UserValidator;
-import com.back2basics.mention.MentionNotificationSender;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,98 +17,23 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @RequiredArgsConstructor
 public class PostCreateService implements PostCreateUseCase {
-
-    private final PostCreatePort postCreatePort;
-    private final ProjectValidator projectValidator;
-    private final PostValidator postValidator;
-    private final UserValidator userValidator;
-    private final FileUploadService fileUploadService;
-    private final FileSavePort fileSavePort;
-    private final PostNotificationSender postNotificationSender;
-    private final MentionNotificationSender mentionNotificationSender;
-    private final HistoryLogService historyLogService;
-    private final LinkCreateService linkCreateService;
+    private final PostCreateProcessor processor;
 
     @Override
-    public PostCreateResult createPost(Long userId, Long projectId, Long projectStepId,
+    @Transactional
+    public PostCreateResult createPost(Long userId, Long projectId, Long stepId,
         String userIp, PostCreateCommand command, List<MultipartFile> files) throws IOException {
 
-        userValidator.validateNotFoundUserId(userId);
-        projectValidator.findById(projectId);
-        postValidator.findParentPost(command.getParentId());
-
-        Post post = Post.createFromCommand(command, userId, userIp);
-        Post savedPost = postCreatePort.save(post);
-
-        uploadAndSaveFiles(files, savedPost.getId());
-        linkCreateService.createLinks(command.getNewLinks(), savedPost.getId());
-
-        postNotificationSender.sendNotification(userId, savedPost.getId(), command);
-        mentionNotificationSender.notifyMentionedUsers(userId, projectId, savedPost.getId(),
-            post.getContent());
-
-        historyLogService.logCreated(DomainType.POST, userId, savedPost, "게시글 생성");
-        return PostCreateResult.toResult(savedPost);
+        return processor.create(userId, projectId, stepId, userIp, command, files, null);
     }
 
     @Override
     @Transactional
     public PostCreateResult createPostWithPresigned(Long userId, Long projectId, Long stepId,
-        String userIp, PostCreateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles) {
+        String userIp, PostCreateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles)
+        throws IOException {
 
-        userValidator.validateNotFoundUserId(userId);
-        projectValidator.findById(projectId);
-        postValidator.findParentPost(command.getParentId());
-
-        Post post = Post.createFromCommand(command, userId, userIp);
-        Post savedPost = postCreatePort.save(post);
-
-        log.info("======================== createPostWithPresigned() 의 url : {}",
-            uploadedFiles.get(0).getUrl());
-
-        saveFilesFromPresignedUrls(uploadedFiles, savedPost.getId());
-
-        linkCreateService.createLinks(command.getNewLinks(), savedPost.getId());
-        postNotificationSender.sendNotification(userId, savedPost.getId(), command);
-        mentionNotificationSender.notifyMentionedUsers(userId, projectId, savedPost.getId(),
-            post.getContent());
-        historyLogService.logCreated(DomainType.POST, userId, savedPost, "게시글 생성");
-
-        return PostCreateResult.toResult(savedPost);
+        return processor.create(userId, projectId, stepId, userIp, command, null, uploadedFiles);
     }
-
-    private void saveFilesFromPresignedUrls(List<PresignedUploadCompleteInfo> uploadedFiles,
-        Long postId) {
-        if (uploadedFiles == null || uploadedFiles.isEmpty()) {
-            return;
-        }
-
-        log.info("======================== saveFilesFromPresignedUrls() 의 url : {}",
-            uploadedFiles.get(0).getUrl());
-        List<File> fileModels = uploadedFiles.stream()
-            .map(info -> File.create(
-                null,
-                ContentType.POST,
-                postId,
-                info.getOriginalName(),
-                info.getUrl(),
-                info.getExtension(),
-                info.getSize()
-            )).toList();
-        fileSavePort.saveAll(fileModels, postId);
-        log.info(
-            "======================== after fileSavePort.saveAll(fileModels, postId)의 url : {}",
-            uploadedFiles.get(0).getUrl());
-    }
-
-    private void uploadAndSaveFiles(List<MultipartFile> files, Long postId) throws IOException {
-        if (files == null || files.isEmpty()) {
-            return;
-        }
-
-        List<File> fileModels = fileUploadService.upload(files, postId, ContentType.POST);
-        fileSavePort.saveAll(fileModels, postId);
-    }
-
 
 }

--- a/module-core/src/main/java/com/back2basics/board/post/service/PostCreateService.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/PostCreateService.java
@@ -24,16 +24,15 @@ public class PostCreateService implements PostCreateUseCase {
     public PostCreateResult createPost(Long userId, Long projectId, Long stepId,
         String userIp, PostCreateCommand command, List<MultipartFile> files) throws IOException {
 
-        return processor.create(userId, projectId, stepId, userIp, command, files, null);
+        return processor.createWithMultipart(userId, projectId, stepId, userIp, command, files);
     }
 
     @Override
     @Transactional
     public PostCreateResult createPostWithPresigned(Long userId, Long projectId, Long stepId,
-        String userIp, PostCreateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles)
-        throws IOException {
+        String userIp, PostCreateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles) {
 
-        return processor.create(userId, projectId, stepId, userIp, command, null, uploadedFiles);
+        return processor.createWithPresigned(userId, projectId, stepId, userIp, command, uploadedFiles);
     }
 
 }

--- a/module-core/src/main/java/com/back2basics/board/post/service/PostFileService.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/PostFileService.java
@@ -2,6 +2,8 @@ package com.back2basics.board.post.service;
 
 import com.back2basics.file.model.ContentType;
 import com.back2basics.file.model.File;
+import com.back2basics.file.port.out.FileDeletePort;
+import com.back2basics.file.port.out.FileReadPort;
 import com.back2basics.file.port.out.FileSavePort;
 import com.back2basics.file.service.FileUploadService;
 import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
@@ -17,6 +19,9 @@ public class PostFileService {
 
     private final FileUploadService fileUploadService;
     private final FileSavePort fileSavePort;
+    private final FileDeletePort fileDeletePort;
+    private final FileReadPort fileReadPort;
+
 
     public void uploadAndSave(List<MultipartFile> files, Long postId) throws IOException {
         if (files == null || files.isEmpty()) return;
@@ -33,5 +38,40 @@ public class PostFileService {
                 info.getExtension(), info.getSize()
             )).toList();
         fileSavePort.saveAll(fileModels, postId);
+    }
+
+    public void replaceFiles(List<MultipartFile> files, List<Long> fileIdsToDelete, Long postId) throws IOException {
+        List<File> toDelete = getFilesToDelete(fileIdsToDelete, postId);
+        fileDeletePort.deleteFiles(toDelete);
+        fileDeletePort.deleteFromStorage(toDelete);
+
+        if (files != null && !files.isEmpty()) {
+            List<File> newFiles = fileUploadService.upload(files, postId, ContentType.POST);
+            fileSavePort.saveAll(newFiles, postId);
+        }
+    }
+
+    public void replacePresignedFiles(List<PresignedUploadCompleteInfo> uploadedFiles, List<Long> fileIdsToDelete, Long postId) {
+        List<File> toDelete = getFilesToDelete(fileIdsToDelete, postId);
+        fileDeletePort.deleteFiles(toDelete);
+        fileDeletePort.deleteFromStorage(toDelete);
+
+        if (uploadedFiles != null && !uploadedFiles.isEmpty()) {
+            List<File> newFiles = uploadedFiles.stream()
+                .map(info -> File.create(
+                    null, ContentType.POST, postId,
+                    info.getOriginalName(), info.getUrl(),
+                    info.getExtension(), info.getSize()
+                )).toList();
+            fileSavePort.saveAll(newFiles, postId);
+        }
+    }
+
+    private List<File> getFilesToDelete(List<Long> fileIdsToDelete, Long postId) {
+        if (fileIdsToDelete == null || fileIdsToDelete.isEmpty()) return List.of();
+        List<File> existingFiles = fileReadPort.getFilesByReferenceId(postId);
+        return existingFiles.stream()
+            .filter(f -> fileIdsToDelete.contains(f.getId()))
+            .toList();
     }
 }

--- a/module-core/src/main/java/com/back2basics/board/post/service/PostFileService.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/PostFileService.java
@@ -1,0 +1,37 @@
+package com.back2basics.board.post.service;
+
+import com.back2basics.file.model.ContentType;
+import com.back2basics.file.model.File;
+import com.back2basics.file.port.out.FileSavePort;
+import com.back2basics.file.service.FileUploadService;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class PostFileService {
+
+    private final FileUploadService fileUploadService;
+    private final FileSavePort fileSavePort;
+
+    public void uploadAndSave(List<MultipartFile> files, Long postId) throws IOException {
+        if (files == null || files.isEmpty()) return;
+        List<File> fileModels = fileUploadService.upload(files, postId, ContentType.POST);
+        fileSavePort.saveAll(fileModels, postId);
+    }
+
+    public void savePresigned(List<PresignedUploadCompleteInfo> uploadedFiles, Long postId) {
+        if (uploadedFiles == null || uploadedFiles.isEmpty()) return;
+        List<File> fileModels = uploadedFiles.stream()
+            .map(info -> File.create(
+                null, ContentType.POST, postId,
+                info.getOriginalName(), info.getUrl(),
+                info.getExtension(), info.getSize()
+            )).toList();
+        fileSavePort.saveAll(fileModels, postId);
+    }
+}

--- a/module-core/src/main/java/com/back2basics/board/post/service/PostUpdateService.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/PostUpdateService.java
@@ -19,14 +19,13 @@ public class PostUpdateService implements PostUpdateUseCase {
     @Override
     public void updatePost(Long userId, String userIp, Long postId,
         PostUpdateCommand command, List<MultipartFile> files) throws IOException {
-        processor.update(userId, userIp, postId, command, files, null);
+        processor.updateWithMultipart(userId, userIp, postId, command, files);
     }
 
     @Override
     public void updatePostWithPresigned(Long userId, String userIp, Long postId,
-        PostUpdateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles)
-        throws IOException {
-        processor.update(userId, userIp, postId, command, null, uploadedFiles);
+        PostUpdateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles) {
+        processor.updateWithPresigned(userId, userIp, postId, command, uploadedFiles);
     }
 //
 //    private final PostUpdatePort postUpdatePort;

--- a/module-core/src/main/java/com/back2basics/board/post/service/PostUpdateService.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/PostUpdateService.java
@@ -1,21 +1,9 @@
 package com.back2basics.board.post.service;
 
-import com.back2basics.board.link.service.LinkUpdateService;
-import com.back2basics.board.post.model.Post;
 import com.back2basics.board.post.port.in.PostUpdateUseCase;
 import com.back2basics.board.post.port.in.command.PostUpdateCommand;
-import com.back2basics.board.post.port.out.PostUpdatePort;
-import com.back2basics.file.model.ContentType;
-import com.back2basics.file.model.File;
-import com.back2basics.file.port.out.FileDeletePort;
-import com.back2basics.file.port.out.FileReadPort;
-import com.back2basics.file.port.out.FileSavePort;
-import com.back2basics.file.service.FileUploadService;
-import com.back2basics.history.model.DomainType;
-import com.back2basics.history.service.HistoryLogService;
+import com.back2basics.board.post.service.utils.PostUpdateProcessor;
 import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
-import com.back2basics.infra.validator.PostValidator;
-import com.back2basics.mention.MentionNotificationSender;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,110 +14,126 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class PostUpdateService implements PostUpdateUseCase {
 
-    private final PostUpdatePort postUpdatePort;
-    private final PostValidator postValidator;
-    private final FileUploadService fileUploadService;
-    private final FileSavePort fileSavePort;
-    private final FileDeletePort fileDeletePort;
-    private final FileReadPort fileReadPort;
-    private final MentionNotificationSender mentionNotificationSender;
-    private final HistoryLogService historyLogService;
-    private final LinkUpdateService linkUpdateService;
+    private final PostUpdateProcessor processor;
 
     @Override
     public void updatePost(Long userId, String userIp, Long postId,
         PostUpdateCommand command, List<MultipartFile> files) throws IOException {
-        Post post = postValidator.findPost(postId);
-        Post beforePost = Post.copyOf(post);
-
-        post.update(command, userIp);
-
-        Post updatedPost = postUpdatePort.update(post);
-        linkUpdateService.updateLinks(
-            command.getNewLinks(),
-            command.getLinkIdsToDelete(),
-            updatedPost.getId()
-        );
-
-        mentionNotificationSender.notifyMentionedUsers(userId, post.getProjectId(), postId,
-            post.getContent());
-
-        replaceFiles(files, command.getFileIdsToDelete(), updatedPost.getId());
-
-        historyLogService.logUpdated(DomainType.POST, userId, beforePost, updatedPost, "게시글 정보 수정");
-    }
-
-    private void replaceFiles(List<MultipartFile> files, List<Long> fileIdsToDelete, Long postId)
-        throws IOException {
-
-        List<Long> finalFileIdsToDelete = (fileIdsToDelete != null) ? fileIdsToDelete : List.of();
-
-        List<File> existingFiles = fileReadPort.getFilesByReferenceId(postId);
-
-        List<File> toDelete = existingFiles.stream()
-            .filter(f -> finalFileIdsToDelete.contains(f.getId()))
-            .toList();
-
-        fileDeletePort.deleteFiles(toDelete);
-        fileDeletePort.deleteFromStorage(toDelete);
-
-        if (files != null && !files.isEmpty()) {
-            List<File> newFiles = fileUploadService.upload(files, postId, ContentType.POST);
-            fileSavePort.saveAll(newFiles, postId);
-        }
+        processor.update(userId, userIp, postId, command, files, null);
     }
 
     @Override
     public void updatePostWithPresigned(Long userId, String userIp, Long postId,
-        PostUpdateCommand command,
-        List<PresignedUploadCompleteInfo> uploadedFiles) {
-        Post post = postValidator.findPost(postId);
-        Post beforePost = Post.copyOf(post);
-
-        post.update(command, userIp);
-        Post updatedPost = postUpdatePort.update(post);
-
-        linkUpdateService.updateLinks(
-            command.getNewLinks(),
-            command.getLinkIdsToDelete(),
-            updatedPost.getId()
-        );
-
-        mentionNotificationSender.notifyMentionedUsers(userId, post.getProjectId(), postId,
-            post.getContent());
-
-        replacePresignedFiles(uploadedFiles, command.getFileIdsToDelete(), updatedPost.getId());
-
-        historyLogService.logUpdated(DomainType.POST, userId, beforePost, updatedPost, "게시글 정보 수정");
+        PostUpdateCommand command, List<PresignedUploadCompleteInfo> uploadedFiles)
+        throws IOException {
+        processor.update(userId, userIp, postId, command, null, uploadedFiles);
     }
+//
+//    private final PostUpdatePort postUpdatePort;
+//    private final PostValidator postValidator;
+//    private final FileUploadService fileUploadService;
+//    private final FileSavePort fileSavePort;
+//    private final FileDeletePort fileDeletePort;
+//    private final FileReadPort fileReadPort;
+//    private final MentionNotificationSender mentionNotificationSender;
+//    private final HistoryLogService historyLogService;
+//    private final LinkUpdateService linkUpdateService;
+//
+//    @Override
+//    public void updatePost(Long userId, String userIp, Long postId,
+//        PostUpdateCommand command, List<MultipartFile> files) throws IOException {
+//        Post post = postValidator.findPost(postId);
+//        Post beforePost = Post.copyOf(post);
+//
+//        post.update(command, userIp);
+//
+//        Post updatedPost = postUpdatePort.update(post);
+//        linkUpdateService.updateLinks(
+//            command.getNewLinks(),
+//            command.getLinkIdsToDelete(),
+//            updatedPost.getId()
+//        );
+//
+//        mentionNotificationSender.notifyMentionedUsers(userId, post.getProjectId(), postId,
+//            post.getContent());
+//
+//        replaceFiles(files, command.getFileIdsToDelete(), updatedPost.getId());
+//
+//        historyLogService.logUpdated(DomainType.POST, userId, beforePost, updatedPost, "게시글 정보 수정");
+//    }
+//
+//    private void replaceFiles(List<MultipartFile> files, List<Long> fileIdsToDelete, Long postId)
+//        throws IOException {
+//
+//        List<Long> finalFileIdsToDelete = (fileIdsToDelete != null) ? fileIdsToDelete : List.of();
+//
+//        List<File> existingFiles = fileReadPort.getFilesByReferenceId(postId);
+//
+//        List<File> toDelete = existingFiles.stream()
+//            .filter(f -> finalFileIdsToDelete.contains(f.getId()))
+//            .toList();
+//
+//        fileDeletePort.deleteFiles(toDelete);
+//        fileDeletePort.deleteFromStorage(toDelete);
+//
+//        if (files != null && !files.isEmpty()) {
+//            List<File> newFiles = fileUploadService.upload(files, postId, ContentType.POST);
+//            fileSavePort.saveAll(newFiles, postId);
+//        }
+//    }
+//
+//    @Override
+//    public void updatePostWithPresigned(Long userId, String userIp, Long postId,
+//        PostUpdateCommand command,
+//        List<PresignedUploadCompleteInfo> uploadedFiles) {
+//        Post post = postValidator.findPost(postId);
+//        Post beforePost = Post.copyOf(post);
+//
+//        post.update(command, userIp);
+//        Post updatedPost = postUpdatePort.update(post);
+//
+//        linkUpdateService.updateLinks(
+//            command.getNewLinks(),
+//            command.getLinkIdsToDelete(),
+//            updatedPost.getId()
+//        );
+//
+//        mentionNotificationSender.notifyMentionedUsers(userId, post.getProjectId(), postId,
+//            post.getContent());
+//
+//        replacePresignedFiles(uploadedFiles, command.getFileIdsToDelete(), updatedPost.getId());
+//
+//        historyLogService.logUpdated(DomainType.POST, userId, beforePost, updatedPost, "게시글 정보 수정");
+//    }
+//
+//    private void replacePresignedFiles(List<PresignedUploadCompleteInfo> uploadedFiles,
+//        List<Long> fileIdsToDelete, Long postId) {
+//        List<Long> finalFileIdsToDelete = (fileIdsToDelete != null) ? fileIdsToDelete : List.of();
+//
+//        List<File> existingFiles = fileReadPort.getFilesByReferenceId(postId);
+//
+//        List<File> toDelete = existingFiles.stream()
+//            .filter(f -> finalFileIdsToDelete.contains(f.getId()))
+//            .toList();
+//
+//        fileDeletePort.deleteFiles(toDelete);
+//        fileDeletePort.deleteFromStorage(toDelete);
+//
+//        if (uploadedFiles != null && !uploadedFiles.isEmpty()) {
+//            List<File> newFiles = uploadedFiles.stream()
+//                .map(info -> File.create(
+//                    null,
+//                    ContentType.POST,
+//                    postId,
+//                    info.getOriginalName(),
+//                    info.getUrl(),
+//                    info.getExtension(),
+//                    info.getSize()
+//                ))
+//                .toList();
+//            fileSavePort.saveAll(newFiles, postId);
+//        }
+//    }
 
-    private void replacePresignedFiles(List<PresignedUploadCompleteInfo> uploadedFiles,
-        List<Long> fileIdsToDelete, Long postId) {
-        List<Long> finalFileIdsToDelete = (fileIdsToDelete != null) ? fileIdsToDelete : List.of();
-
-        List<File> existingFiles = fileReadPort.getFilesByReferenceId(postId);
-
-        List<File> toDelete = existingFiles.stream()
-            .filter(f -> finalFileIdsToDelete.contains(f.getId()))
-            .toList();
-
-        fileDeletePort.deleteFiles(toDelete);
-        fileDeletePort.deleteFromStorage(toDelete);
-
-        if (uploadedFiles != null && !uploadedFiles.isEmpty()) {
-            List<File> newFiles = uploadedFiles.stream()
-                .map(info -> File.create(
-                    null,
-                    ContentType.POST,
-                    postId,
-                    info.getOriginalName(),
-                    info.getUrl(),
-                    info.getExtension(),
-                    info.getSize()
-                ))
-                .toList();
-            fileSavePort.saveAll(newFiles, postId);
-        }
-    }
 
 }

--- a/module-core/src/main/java/com/back2basics/board/post/service/utils/PostCreateProcessor.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/utils/PostCreateProcessor.java
@@ -1,0 +1,66 @@
+package com.back2basics.board.post.service.utils;
+
+import com.back2basics.board.link.service.LinkCreateService;
+import com.back2basics.board.post.model.Post;
+import com.back2basics.board.post.port.in.command.PostCreateCommand;
+import com.back2basics.board.post.port.out.PostCreatePort;
+import com.back2basics.board.post.service.PostFileService;
+import com.back2basics.board.post.service.notification.PostNotificationSender;
+import com.back2basics.board.post.service.result.PostCreateResult;
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
+import com.back2basics.infra.validator.PostValidator;
+import com.back2basics.infra.validator.ProjectValidator;
+import com.back2basics.infra.validator.UserValidator;
+import com.back2basics.mention.MentionNotificationSender;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@Component
+@RequiredArgsConstructor
+public class PostCreateProcessor {
+
+    private final PostValidator validator;
+    private final ProjectValidator projectValidator;
+    private final UserValidator userValidator;
+    private final PostCreatePort postCreatePort;
+    private final PostFileService postFileService;
+    private final LinkCreateService linkCreateService;
+    private final PostNotificationSender postNotificationSender;
+    private final MentionNotificationSender mentionNotificationSender;
+    private final HistoryLogService historyLogService;
+
+    public PostCreateResult create(Long userId, Long projectId, Long stepId, String userIp,
+        PostCreateCommand command, List<MultipartFile> files, List<PresignedUploadCompleteInfo> uploadedFiles)
+        throws IOException {
+
+        userValidator.validateNotFoundUserId(userId);
+        projectValidator.findById(projectId);
+        validator.findParentPost(command.getParentId());
+
+        Post post = Post.createFromCommand(command, userId, userIp);
+        Post savedPost = postCreatePort.save(post);
+
+        if (files != null) {
+            postFileService.uploadAndSave(files, savedPost.getId());
+        }
+
+        if (uploadedFiles != null) {
+            postFileService.savePresigned(uploadedFiles, savedPost.getId());
+        }
+
+        linkCreateService.createLinks(command.getNewLinks(), savedPost.getId());
+
+        postNotificationSender.sendNotification(userId, savedPost.getId(), command);
+        mentionNotificationSender.notifyMentionedUsers(userId, projectId, savedPost.getId(), post.getContent());
+
+        historyLogService.logCreated(DomainType.POST, userId, savedPost, "게시글 생성");
+
+        return PostCreateResult.toResult(savedPost);
+    }
+}

--- a/module-core/src/main/java/com/back2basics/board/post/service/utils/PostFileService.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/utils/PostFileService.java
@@ -1,4 +1,4 @@
-package com.back2basics.board.post.service;
+package com.back2basics.board.post.service.utils;
 
 import com.back2basics.file.model.ContentType;
 import com.back2basics.file.model.File;

--- a/module-core/src/main/java/com/back2basics/board/post/service/utils/PostUpdateProcessor.java
+++ b/module-core/src/main/java/com/back2basics/board/post/service/utils/PostUpdateProcessor.java
@@ -1,0 +1,54 @@
+package com.back2basics.board.post.service.utils;
+
+import com.back2basics.board.link.service.LinkUpdateService;
+import com.back2basics.board.post.model.Post;
+import com.back2basics.board.post.port.in.command.PostUpdateCommand;
+import com.back2basics.board.post.port.out.PostUpdatePort;
+import com.back2basics.board.post.service.PostFileService;
+import com.back2basics.history.model.DomainType;
+import com.back2basics.history.service.HistoryLogService;
+import com.back2basics.infra.s3.dto.PresignedUploadCompleteInfo;
+import com.back2basics.infra.validator.PostValidator;
+import com.back2basics.mention.MentionNotificationSender;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@RequiredArgsConstructor
+public class PostUpdateProcessor {
+
+    private final PostValidator postValidator;
+    private final PostUpdatePort postUpdatePort;
+    private final LinkUpdateService linkUpdateService;
+    private final MentionNotificationSender mentionNotificationSender;
+    private final HistoryLogService historyLogService;
+    private final PostFileService postFileService;
+
+    public void update(Long userId, String userIp, Long postId,
+        PostUpdateCommand command,
+        List<MultipartFile> files,
+        List<PresignedUploadCompleteInfo> uploadedFiles) throws IOException {
+
+        Post post = postValidator.findPost(postId);
+        Post beforePost = Post.copyOf(post);
+
+        post.update(command, userIp);
+        Post updatedPost = postUpdatePort.update(post);
+
+        linkUpdateService.updateLinks(command.getNewLinks(), command.getLinkIdsToDelete(), updatedPost.getId());
+
+        if (files != null) {
+            postFileService.replaceFiles(files, command.getFileIdsToDelete(), updatedPost.getId());
+        }
+
+        if (uploadedFiles != null) {
+            postFileService.replacePresignedFiles(uploadedFiles, command.getFileIdsToDelete(), updatedPost.getId());
+        }
+
+        mentionNotificationSender.notifyMentionedUsers(userId, post.getProjectId(), updatedPost.getId(), post.getContent());
+        historyLogService.logUpdated(DomainType.POST, userId, beforePost, updatedPost, "게시글 정보 수정");
+    }
+}

--- a/module-core/src/main/java/com/back2basics/company/model/Company.java
+++ b/module-core/src/main/java/com/back2basics/company/model/Company.java
@@ -74,6 +74,7 @@ public class Company implements TargetDomain {
             .createdAt(company.getCreatedAt())
             .updatedAt(company.getUpdatedAt())
             .deletedAt(company.getDeletedAt())
+            .userCount(company.getUserCount())
             .build();
     }
 

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/assignment/AssignmentEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/assignment/AssignmentEntity.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -22,7 +23,9 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
-@Table(name = "assignments")
+@Table(name = "assignments",
+    indexes = @Index(name = "idx_assignments_user_project", columnList = "user_id, project_id")
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AssignmentEntity {
 

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/adapter/PostReadJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/adapter/PostReadJpaAdapter.java
@@ -148,7 +148,7 @@ public class PostReadJpaAdapter implements PostReadPort {
                 postEntity.projectId.eq(projectId)
                 //postEntity.projectStepId.eq(projectStepId)
             )
-            .orderBy(postEntity.createdAt.desc())
+            .orderBy(postEntity.id.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
@@ -184,7 +184,7 @@ public class PostReadJpaAdapter implements PostReadPort {
             ))
             .from(postEntity)
             .where(postEntity.deletedAt.isNull())
-            .orderBy(postEntity.createdAt.desc())
+            .orderBy(postEntity.id.desc())
             .limit(5)
             .fetch();
     }
@@ -219,7 +219,7 @@ public class PostReadJpaAdapter implements PostReadPort {
                         .where(assignmentEntity.user.id.eq(userId))
                 )
             )
-            .orderBy(postEntity.createdAt.desc())
+            .orderBy(postEntity.id.desc())
             .limit(5)
             .fetch();
 
@@ -258,7 +258,7 @@ public class PostReadJpaAdapter implements PostReadPort {
                         .where(assignmentEntity.user.id.eq(userId))
                 )
             )
-            .orderBy(postEntity.createdAt.desc())
+            .orderBy(postEntity.id.desc())
             .limit(5)
             .fetch();
 

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/adapter/PostReadJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/adapter/PostReadJpaAdapter.java
@@ -22,7 +22,6 @@ import com.back2basics.file.model.File;
 import com.back2basics.file.port.out.FileReadPort;
 import com.back2basics.infra.exception.post.PostException;
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -192,7 +191,7 @@ public class PostReadJpaAdapter implements PostReadPort {
     @Override
     public List<Post> getPostsWithProjectIdAndDueSoon(Long userId) {
         List<PostDashboardProjection> projections = queryFactory
-            .select(Projections.constructor(
+            .selectDistinct(Projections.constructor(
                 PostDashboardProjection.class,
                 postEntity.id,
                 projectEntity.name.as("projectName"),
@@ -207,17 +206,13 @@ public class PostReadJpaAdapter implements PostReadPort {
             ))
             .from(postEntity)
             .join(projectEntity).on(postEntity.projectId.eq(projectEntity.id))
+            .join(assignmentEntity).on(projectEntity.id.eq(assignmentEntity.project.id))
             .join(projectStepEntity).on(postEntity.projectStepId.eq(projectStepEntity.id))
             .join(userEntity).on(postEntity.authorId.eq(userEntity.id))
             .where(
                 postEntity.deletedAt.isNull(),
-//                projectEntity.projectStatus.eq(ProjectStatus.IN_PROGRESS),
-                projectEntity.id.in(
-                    JPAExpressions
-                        .select(assignmentEntity.project.id)
-                        .from(assignmentEntity)
-                        .where(assignmentEntity.user.id.eq(userId))
-                )
+                assignmentEntity.user.id.eq(userId)
+                // 필요 시 주석 해제: projectEntity.projectStatus.eq(ProjectStatus.IN_PROGRESS)
             )
             .orderBy(postEntity.id.desc())
             .limit(5)
@@ -231,7 +226,7 @@ public class PostReadJpaAdapter implements PostReadPort {
     @Override
     public List<Post> getHighPriorityPostsByUserId(Long userId) {
         List<PostDashboardProjection> projections = queryFactory
-            .select(Projections.constructor(
+            .selectDistinct(Projections.constructor(
                 PostDashboardProjection.class,
                 postEntity.id,
                 projectEntity.name.as("projectName"),
@@ -246,17 +241,13 @@ public class PostReadJpaAdapter implements PostReadPort {
             ))
             .from(postEntity)
             .join(projectEntity).on(postEntity.projectId.eq(projectEntity.id))
+            .join(assignmentEntity).on(projectEntity.id.eq(assignmentEntity.project.id))
             .join(projectStepEntity).on(postEntity.projectStepId.eq(projectStepEntity.id))
             .join(userEntity).on(postEntity.authorId.eq(userEntity.id))
             .where(
+                assignmentEntity.user.id.eq(userId),
                 postEntity.deletedAt.isNull(),
-                postEntity.priority.in(PostPriority.HIGH, PostPriority.URGENT),
-                projectEntity.id.in(
-                    JPAExpressions
-                        .select(assignmentEntity.project.id)
-                        .from(assignmentEntity)
-                        .where(assignmentEntity.user.id.eq(userId))
-                )
+                postEntity.priority.in(PostPriority.HIGH, PostPriority.URGENT)
             )
             .orderBy(postEntity.id.desc())
             .limit(5)

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/adapter/PostSearchJpaAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/board/post/adapter/PostSearchJpaAdapter.java
@@ -69,7 +69,7 @@ public class PostSearchJpaAdapter implements PostSearchPort {
                 matchesType(command.getType()),
                 matchesStep(command.getProjectStepId())
             )
-            .orderBy(postEntity.createdAt.desc())
+            .orderBy(postEntity.id.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistoryReadAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistoryReadAdapter.java
@@ -43,7 +43,7 @@ public class HistoryReadAdapter implements HistoryReadPort {
     public Page<HistorySimpleResult> getHistories(Pageable pageable) {
         Query query = new Query()
             .with(pageable)
-            .with(Sort.by(Sort.Direction.DESC, "history_created_at"));
+            .with(Sort.by(Sort.Direction.DESC, "_id"));
 
         List<HistoryDocument> documents = mongoTemplate.find(query, HistoryDocument.class);
         long total = mongoTemplate.count(new Query(), HistoryDocument.class);

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistoryReadAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistoryReadAdapter.java
@@ -45,6 +45,18 @@ public class HistoryReadAdapter implements HistoryReadPort {
             .with(pageable)
             .with(Sort.by(Sort.Direction.DESC, "_id"));
 
+        query.fields()
+            .include("_id")
+            .include("history_type")
+            .include("domain_type")
+            .include("domain_id")
+            .include("changed_at")
+            .include("changer_id")
+            .include("changer_name")
+            .include("changer_username")
+            .include("changer_role")
+            .include("message");
+
         List<HistoryDocument> documents = mongoTemplate.find(query, HistoryDocument.class);
         long total = mongoTemplate.count(query, HistoryDocument.class);
 

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistoryReadAdapter.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/history/HistoryReadAdapter.java
@@ -46,7 +46,7 @@ public class HistoryReadAdapter implements HistoryReadPort {
             .with(Sort.by(Sort.Direction.DESC, "_id"));
 
         List<HistoryDocument> documents = mongoTemplate.find(query, HistoryDocument.class);
-        long total = mongoTemplate.count(new Query(), HistoryDocument.class);
+        long total = mongoTemplate.count(query, HistoryDocument.class);
 
         List<HistorySimpleResult> results = documents.stream()
             .map(historyMapper::toSimpleResult)

--- a/module-infra/src/main/java/com/back2basics/adapter/persistence/user/entity/UserEntity.java
+++ b/module-infra/src/main/java/com/back2basics/adapter/persistence/user/entity/UserEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,7 +24,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "users")
+@Table(name = "users",
+    indexes =  @Index(name = "idx_user_username", columnList = "username")
+)
 public class UserEntity extends BaseTimeEntity {
 
     @Id

--- a/module-infra/src/main/java/com/back2basics/bulk/CommentBulkInitializer.java
+++ b/module-infra/src/main/java/com/back2basics/bulk/CommentBulkInitializer.java
@@ -1,0 +1,66 @@
+//package com.back2basics.bulk;
+//
+//import com.back2basics.adapter.persistence.comment.CommentEntity;
+//import com.back2basics.adapter.persistence.comment.CommentEntityRepository;
+//import java.time.LocalDateTime;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Random;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.stereotype.Component;
+//
+//@Slf4j
+//@Component
+//@RequiredArgsConstructor
+//public class CommentBulkInitializer implements CommandLineRunner {
+//
+//    long start = System.currentTimeMillis();
+//
+//    private final CommentEntityRepository commentRepository;
+//    private static final Random RANDOM = new Random();
+//
+//    @Override
+//    public void run(String... args) {
+//        int total = 100000; // 원하는 개수
+//        int batchSize = 10_000;
+//        List<CommentEntity> batch = new ArrayList<>();
+//
+//        for (int i = 1; i <= total; i++) {
+//            CommentEntity comment = new CommentEntity();
+//            comment.setAuthorIp(randomIp());
+//            comment.setAuthorId(randomLong(1, 3));
+//            comment.setContent("댓글 내용 #" + i);
+//            comment.setPostId(randomLong(1,10000)); // 테스트 대상 게시글 ID
+//            comment.setParentId(null);
+//            comment.setCreatedAt(LocalDateTime.now());
+//            comment.setUpdatedAt(LocalDateTime.now());
+//
+//            batch.add(comment);
+//
+//            if (batch.size() == batchSize) {
+//                commentRepository.saveAll(batch);
+//                batch.clear();
+//                log.info("Saved batch up to comment {}", i);
+//            }
+//        }
+//
+//        if (!batch.isEmpty()) {
+//            commentRepository.saveAll(batch);
+//            log.info("Saved final batch of {} comments", batch.size());
+//        }
+//
+//        long end = System.currentTimeMillis(); // ⏱ 종료 시간 측정
+//        log.info("⏳ 전체 소요 시간: {} ms", (end - start));
+//    }
+//
+//    private long randomLong(long min, long max) {
+//        return min + RANDOM.nextInt((int)(max - min + 1));
+//    }
+//
+//    private String randomIp() {
+//        return RANDOM.nextInt(256) + "." + RANDOM.nextInt(256) + "." +
+//            RANDOM.nextInt(256) + "." + RANDOM.nextInt(256);
+//    }
+//}


### PR DESCRIPTION
## 📌 개요  
게시글 관련 파일 업로드 방식 분리(Presigned / Multipart)
조회 성능 개선을 위한 쿼리 튜닝 및 인덱스 최적화
정렬 기준 수정 등을 포함한 리팩토링 작업

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [x] 기타 (Other)

## ✅ 작업 내용 상세
- 게시글 생성/수정 시 파일 업로드 방식을 Presigned / Multipart로 분리 (Processor 도입)
- PostFileService 도입으로 파일 저장 책임 분리
- 게시글 조회 시 정렬 기준을 `id DESC`로 변경하여 인덱스 타도록 최적화
- assignment 엔티티에 복합 인덱스 추가 (project_id, user_id)
- 멘션 기능 성능 개선을 위해 `UserEntity.username`에 인덱스 추가
- 회사 목록, 관리자 필터링 목록 등의 정렬 기준을 생성일 → ID 역순으로 변경
- 게시글 관련 Projection 튜닝 (`Projections.constructor` 기반)

## 🔍 관련 이슈
- Close #559  
- See also #556, #567, #568

## 🧪 테스트 결과
- Postman으로 게시글 생성/수정 API 테스트 (Multipart, Presigned 방식 모두 정상 동작)
- 멘션 및 이력 기능 정상 동작 확인
- 정렬 기준 변경 이후 응답 속도 향상 확인

## 👀 리뷰어에게 요청사항

## 📎 기타 참고 사항
