### PR TITLE
[Hotfix] 문자열길이제한 커스텀어노테이션 추가, 프로젝트컨트롤러 응답메세지 추가

### DIFF
--- a/module-api/src/main/java/com/back2basics/custom/CustomStringLengthCheck.java
+++ b/module-api/src/main/java/com/back2basics/custom/CustomStringLengthCheck.java
@@ -1,0 +1,24 @@
+package com.back2basics.custom;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = CustomStringLengthValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomStringLengthCheck {
+
+    int min();
+
+    int max();
+
+    String message() default "너무 많은 내용을 담을 수 없습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/module-api/src/main/java/com/back2basics/custom/CustomStringLengthValidator.java
+++ b/module-api/src/main/java/com/back2basics/custom/CustomStringLengthValidator.java
@@ -1,0 +1,23 @@
+package com.back2basics.custom;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class CustomStringLengthValidator implements ConstraintValidator<CustomStringLengthCheck, String> {
+
+    private int min;
+    private int max;
+
+    @Override
+    public void initialize(CustomStringLengthCheck constraintAnnotation) {
+        this.min = constraintAnnotation.min();
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true; // @NotBlank로 따로 처리하도록 수정 : null은 허용
+        int length = value.length();
+        return length >= min && length <= max;
+    }
+}

--- a/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostCreateRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostCreateRequest.java
@@ -5,6 +5,7 @@ import com.back2basics.board.post.model.PostType;
 import com.back2basics.board.post.port.in.command.PostCreateCommand;
 import com.back2basics.custom.CustomEnumCheck;
 import com.back2basics.custom.CustomLinkCheck;
+import com.back2basics.custom.CustomStringLengthCheck;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,9 +19,11 @@ public class PostCreateRequest {
     private Long parentId;
 
     @NotBlank(message = "제목은 필수입니다.")
+    @CustomStringLengthCheck(min = 1, max = 50, message = "게시글 제목은 30자 이하로 입력해주세요")
     private String title;
 
-    @NotBlank(message = "내용은 필수입니다.")
+    @NotBlank(message = "내용이 비어있을 수 없습니다.")
+    @CustomStringLengthCheck(min = 1, max = 50, message = "게시글 내용은 1,000자 이하로 입력해주세요")
     private String content;
 
     @NotNull(message = "타입이 입력되지 않았습니다.")

--- a/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostUpdateRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/board/dto/request/PostUpdateRequest.java
@@ -5,6 +5,7 @@ import com.back2basics.board.post.model.PostType;
 import com.back2basics.board.post.port.in.command.PostUpdateCommand;
 import com.back2basics.custom.CustomEnumCheck;
 import com.back2basics.custom.CustomLinkCheck;
+import com.back2basics.custom.CustomStringLengthCheck;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -14,9 +15,11 @@ import lombok.Getter;
 public class PostUpdateRequest {
 
     @NotBlank(message = "제목은 필수입니다.")
+    @CustomStringLengthCheck(min = 1, max = 50, message = "게시글 제목은 30자 이하로 입력해주세요")
     private String title;
 
-    @NotBlank(message = "내용은 필수입니다.")
+    @NotBlank(message = "내용이 비어있을 수 없습니다.")
+    @CustomStringLengthCheck(min = 1, max = 50, message = "게시글 내용은 1,000자 이하로 입력해주세요")
     private String content;
 
     @NotNull(message = "타입이 입력되지 않았습니다.")

--- a/module-api/src/main/java/com/back2basics/domain/comment/dto/request/CommentCreateRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,6 +1,7 @@
 package com.back2basics.domain.comment.dto.request;
 
 import com.back2basics.comment.port.in.command.CommentCreateCommand;
+import com.back2basics.custom.CustomStringLengthCheck;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -16,6 +17,7 @@ public class CommentCreateRequest {
     private Long parentId; // 이게 null이 아니면 대댓글임
 
     @NotBlank(message = "내용을 입력해주세요.")
+    @CustomStringLengthCheck(min = 1, max = 50, message = "댓글 내용은 50자 이하로 입력해주세요")
     private String content;
 
     public CommentCreateCommand toCommand() {

--- a/module-api/src/main/java/com/back2basics/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.back2basics.domain.comment.dto.request;
 
 import com.back2basics.comment.port.in.command.CommentUpdateCommand;
+import com.back2basics.custom.CustomStringLengthCheck;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
@@ -8,6 +9,7 @@ import lombok.Getter;
 public class CommentUpdateRequest {
 
     @NotBlank(message = "내용을 입력해주세요.")
+    @CustomStringLengthCheck(min = 1, max = 50, message = "댓글 내용은 50자 이하로 입력해주세요")
     private String content;
 
     public CommentUpdateCommand toCommand() {

--- a/module-api/src/main/java/com/back2basics/domain/project/controller/ProjectController.java
+++ b/module-api/src/main/java/com/back2basics/domain/project/controller/ProjectController.java
@@ -1,6 +1,7 @@
 package com.back2basics.domain.project.controller;
 
 import static com.back2basics.domain.project.controller.code.ProjectResponseCode.DELETED_PROJECT_READ_ALL_SUCCESS;
+import static com.back2basics.domain.project.controller.code.ProjectResponseCode.PROJECT_CLIENT_USER_READ_SUCCESS;
 import static com.back2basics.domain.project.controller.code.ProjectResponseCode.PROJECT_COUNT_BY_STATUS_SUCCESS;
 import static com.back2basics.domain.project.controller.code.ProjectResponseCode.PROJECT_CREATE_SUCCESS;
 import static com.back2basics.domain.project.controller.code.ProjectResponseCode.PROJECT_DELETE_SUCCESS;
@@ -247,6 +248,6 @@ public class ProjectController {
         List<ProjectClientUserResponse> response = result.stream()
             .map(ProjectClientUserResponse::from)
             .toList();
-        return ApiResponse.success(PROJECT_READ_ALL_SUCCESS, response);
+        return ApiResponse.success(PROJECT_CLIENT_USER_READ_SUCCESS, response);
     }
 }

--- a/module-api/src/main/java/com/back2basics/domain/project/controller/code/ProjectResponseCode.java
+++ b/module-api/src/main/java/com/back2basics/domain/project/controller/code/ProjectResponseCode.java
@@ -20,7 +20,7 @@ public enum ProjectResponseCode implements ResponseCode {
     PROJECT_COUNT_BY_STATUS_SUCCESS(HttpStatus.OK, "PJ209", "프로젝트 상태별 목록 개수 조회 완료"),
     PROJECT_READ_BY_STATUS_SUCCESS(HttpStatus.OK, "PJ210", "프로젝트 상태에 따른 목록 조회 완료"),
     PROJECT_RESTORE_SUCCESS(HttpStatus.OK, "PJ211", "비활성화 프로젝트 복구 완료"),
-    PROJECT_CLIENT_USER_SUCCESS(HttpStatus.OK, "PJ212", "프로젝트에 할당된 고객사 정보 조회 완료");
+    PROJECT_CLIENT_USER_READ_SUCCESS(HttpStatus.OK, "PJ212", "프로젝트에 할당된 고객사 정보 조회 완료");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## 📌 개요  
문자열 길이 검증을 위한 커스텀 어노테이션 추가 및 댓글/게시글 요청 필드에 적용  


## 🔨 작업 유형 (해당하는 항목에 X 표시)  
- [x] 기능 추가 (Feature)  
- [x] 리팩토링 (Refactor)  

## ✅ 작업 내용 상세  
- 커스텀 어노테이션 `@CustomStringLengthCheck` 생성  
  - `min`, `max` 필수 옵션으로 지정  
  - 공백(null, empty) 자동 검증  
- 댓글 생성/수정 요청에 길이 제한 어노테이션 적용  
- 게시글 수정/삭제 요청에 title, content 길이 제한 적용  
- 공백 검증 메시지와 길이 초과 메시지를 구분할 수 있도록 `@NotBlank` 분리 처리  

## 🔍 관련 이슈  
- Close #576  

## 🧪 테스트 결과  


## 👀 리뷰어에게 요청사항  
- issue #576  사용방법 예시 달아놨습니다.

## 📎 기타 참고 사항  
