### PR TITLE
[feat] 필터링 카테고리 all 추가

### DIFF
--- a/module-core/src/main/java/com/back2basics/project/port/out/SearchProjectPort.java
+++ b/module-core/src/main/java/com/back2basics/project/port/out/SearchProjectPort.java
@@ -7,7 +7,8 @@ import org.springframework.data.domain.Pageable;
 
 public interface SearchProjectPort {
 
-    Page<Project> searchByKeywordAndUserId(Long userId, ProjectSearchCommand command, Pageable pageable);
-
     Page<Project> searchByKeyword(ProjectSearchCommand command, Pageable pageable);
+
+    Page<Project> searchByKeywordAndUserId(Long userId, ProjectSearchCommand command,
+        Pageable pageable);
 }


### PR DESCRIPTION
## 📌 개요
- 검색 필터에 `all` 카테고리를 추가하여, 프로젝트명과 업체명을 동시에 검색할 수 있도록 추가

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 필터링 조건에 `category.equals("all")` 케이스 추가
- QueryDSL에서 프로젝트명 또는 업체명 중 하나라도 keyword를 포함하면 결과에 포함되도록 조건 분기 처리

## 🔍 관련 이슈
<!-- 예: Close #12 -->
- Close #
- See also #

## 🧪 테스트 결과
<!-- 테스트 방법 및 결과 요약 -->
<!-- - Postman으로 회원가입 API 정상 동작 확인 -->

## 👀 리뷰어에게 요청사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분 -->
<!-- - 이메일 형식 검증 로직에 문제 없는지 확인 부탁드립니다. -->

## 📎 기타 참고 사항
<!-- 추가적인 설명이나 참고 자료 (디자인 링크, API 문서 등) -->
<!-- - [API 문서](링크) -->
