### PR TITLE
[Feature] 체크리스트 요청 파라미터 길이제한을 위한 유효성 검증 어노테이션 추가

### DIFF
--- a/module-api/src/main/java/com/back2basics/domain/checklist/controller/ChecklistController.java
+++ b/module-api/src/main/java/com/back2basics/domain/checklist/controller/ChecklistController.java
@@ -25,6 +25,7 @@ import com.back2basics.domain.checklist.dto.response.ChecklistDetailResponse;
 import com.back2basics.domain.checklist.dto.response.ChecklistInfoResponse;
 import com.back2basics.global.response.result.ApiResponse;
 import com.back2basics.security.model.CustomUserDetails;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -55,7 +56,7 @@ public class ChecklistController {
     @PostMapping("/{stepId}")
     public ResponseEntity<ApiResponse<Void>> create(@PathVariable Long stepId,
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        @RequestBody CreateChecklistRequest request) {
+        @Valid @RequestBody CreateChecklistRequest request) {
         createChecklistUseCase.create(stepId, userDetails.getId(),
             request.toCommand());
         return ApiResponse.success(CHECKLIST_REQUEST_CREATE_SUCCESS);
@@ -65,7 +66,7 @@ public class ChecklistController {
     @PutMapping("/{checklistId}")
     public ResponseEntity<ApiResponse<Void>> update(@PathVariable Long checklistId,
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        @RequestBody UpdateChecklistRequest request) {
+        @Valid @RequestBody UpdateChecklistRequest request) {
         updateChecklistUseCase.update(checklistId, userDetails.getId(),
             request.toCommand());
         return ApiResponse.success(CHECKLIST_REQUEST_UPDATE_SUCCESS);
@@ -75,7 +76,7 @@ public class ChecklistController {
     @PutMapping("/approvals/{approvalId}")
     public ResponseEntity<ApiResponse<Void>> updateApproval(@PathVariable Long approvalId,
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        @RequestBody UpdateApprovalRequest request) {
+        @Valid @RequestBody UpdateApprovalRequest request) {
         updateApprovalUseCase.update(approvalId, userDetails.getId(), request.toCommand());
         return ApiResponse.success(CHECKLIST_REQUEST_UPDATE_SUCCESS);
     }

--- a/module-api/src/main/java/com/back2basics/domain/checklist/dto/request/CreateChecklistRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/checklist/dto/request/CreateChecklistRequest.java
@@ -1,9 +1,20 @@
 package com.back2basics.domain.checklist.dto.request;
 
 import com.back2basics.checklist.port.in.command.CreateChecklistCommand;
+import com.back2basics.custom.CustomStringLengthCheck;
+import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
-public record CreateChecklistRequest(String title, String content, List<Long> approvalIds) {
+public record CreateChecklistRequest(
+    @NotBlank(message = "제목은 필수입니다.")
+    @CustomStringLengthCheck(min = 1, max = 30, message = "제목은 1자 이상 30자 이하여야 합니다.")
+    String title,
+
+    @NotBlank(message = "내용은 필수입니다.")
+    @CustomStringLengthCheck(min = 0, max = 500, message = "내용은 최대 500자까지 입력할 수 있습니다.")
+    String content,
+
+    List<Long> approvalIds) {
 
     public CreateChecklistCommand toCommand() {
         return new CreateChecklistCommand(this.title, this.content, this.approvalIds);

--- a/module-api/src/main/java/com/back2basics/domain/checklist/dto/request/UpdateApprovalRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/checklist/dto/request/UpdateApprovalRequest.java
@@ -2,8 +2,15 @@ package com.back2basics.domain.checklist.dto.request;
 
 import com.back2basics.checklist.model.ApprovalStatus;
 import com.back2basics.checklist.port.in.command.UpdateApprovalCommand;
+import com.back2basics.custom.CustomStringLengthCheck;
+import jakarta.validation.constraints.NotBlank;
 
-public record UpdateApprovalRequest(String message, ApprovalStatus status) {
+public record UpdateApprovalRequest(
+
+    @NotBlank(message = "반려 내용은 필수입니다.")
+    @CustomStringLengthCheck(min = 1, max = 100, message = "제목은 1자 이상 100자 이하여야 합니다.")
+    String message,
+    ApprovalStatus status) {
 
     public UpdateApprovalCommand toCommand() {
         return new UpdateApprovalCommand(message, status);

--- a/module-api/src/main/java/com/back2basics/domain/checklist/dto/request/UpdateChecklistRequest.java
+++ b/module-api/src/main/java/com/back2basics/domain/checklist/dto/request/UpdateChecklistRequest.java
@@ -1,8 +1,18 @@
 package com.back2basics.domain.checklist.dto.request;
 
 import com.back2basics.checklist.port.in.command.UpdateChecklistCommand;
+import com.back2basics.custom.CustomStringLengthCheck;
+import jakarta.validation.constraints.NotBlank;
 
-public record UpdateChecklistRequest(String title, String content) {
+public record UpdateChecklistRequest(
+    @NotBlank(message = "제목은 필수입니다.")
+    @CustomStringLengthCheck(min = 1, max = 30, message = "제목은 1자 이상 30자 이하여야 합니다.")
+    String title,
+
+    @NotBlank(message = "내용은 필수입니다.")
+    @CustomStringLengthCheck(min = 0, max = 500, message = "내용은 최대 500자까지 입력할 수 있습니다.")
+    String content
+) {
 
     public UpdateChecklistCommand toCommand() {
         return new UpdateChecklistCommand(title, content);


### PR DESCRIPTION
## 📌 개요
체크리스트 요청 파라미터 길이제한을 위한 유효성 검증 어노테이션 추가

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- 체크리스트 컨트롤러 파라미터에 `@Valid` 어노테이션 추가
- 체크리스트 생성/수정 요청 및 반려사유 메시지에 길이 제한 커스텀 어노테이션 적용

## 🔍 관련 이슈
- Close #595

## 🧪 테스트 결과

## 👀 리뷰어에게 요청사항


## 📎 기타 참고 사항
- 커스텀 어노테이션: `@CustomStringLengthCheck(min=1, max=255)`