### PR TITLE
[hotfix] 프로젝트 멤버 할당 로직 오류 수정

### DIFF
--- a/module-core/src/main/java/com/back2basics/assignment/model/Assignment.java
+++ b/module-core/src/main/java/com/back2basics/assignment/model/Assignment.java
@@ -3,6 +3,7 @@ package com.back2basics.assignment.model;
 import com.back2basics.company.model.CompanyType;
 import com.back2basics.history.strategy.TargetDomain;
 import com.back2basics.project.model.Project;
+import com.back2basics.user.model.User;
 import com.back2basics.user.model.UserType;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,30 +52,32 @@ public class Assignment implements TargetDomain {
             .build();
     }
 
-    //todo: 개발사, 고객사 create로 분리하는게 좋을 지
-    public static List<Assignment> createProjectUser(Project project, List<Long> devManagers,
-        List<Long> clientManagers, List<Long> devUsers, List<Long> clientUsers,
-        List<Long> devCompanyIds, List<Long> clientCompanyIds) {
+    //todo: devUserIds, clientUserIds 삭제 확인
+    public static List<Assignment> createProjectUser(Project project, List<Long> devManagerIds,
+        List<Long> clientManagerIds, List<Long> devUserIds, List<Long> clientUserIds,
+        List<User> devUsers, List<User> clientUsers) {
 
         // index(int)로 stream 사용
-        List<Assignment> developers = IntStream.range(0, devUsers.size())
+        List<Assignment> developers = IntStream.range(0, devUserIds.size())
             .mapToObj(i -> Assignment.builder()
                 .projectId(project.getId())
-                .userId(devUsers.get(i))
-                .companyId(devCompanyIds.get(i))
+                .userId(devUsers.get(i).getId())
+                .companyId(devUsers.get(i).getCompanyId())
                 .userType(
-                    devManagers.contains(devUsers.get(i)) ? UserType.MANAGER : UserType.MEMBER)
+                    devManagerIds.contains(devUsers.get(i).getId()) ? UserType.MANAGER
+                        : UserType.MEMBER)
                 .companyType(CompanyType.DEVELOPER)
                 .build())
             .toList();
 
-        List<Assignment> clients = IntStream.range(0, clientUsers.size())
+        List<Assignment> clients = IntStream.range(0, clientUserIds.size())
             .mapToObj(i -> Assignment.builder()
                 .projectId(project.getId())
-                .userId(clientUsers.get(i))
-                .companyId(clientCompanyIds.get(i))
+                .userId(clientUsers.get(i).getId())
+                .companyId(clientUsers.get(i).getCompanyId())
                 .userType(
-                    clientManagers.contains(clientUsers.get(i)) ? UserType.MANAGER : UserType.MEMBER
+                    clientManagerIds.contains(clientUsers.get(i).getId()) ? UserType.MANAGER
+                        : UserType.MEMBER
                 )
                 .companyType(CompanyType.CLIENT)
                 .build())

--- a/module-core/src/main/java/com/back2basics/project/service/CreateProjectService.java
+++ b/module-core/src/main/java/com/back2basics/project/service/CreateProjectService.java
@@ -65,17 +65,14 @@ public class CreateProjectService implements CreateProjectUseCase {
         }
     }
 
-
+    //todo: hotfix
     private void assignUsers(Project project, ProjectCreateCommand command) {
         List<User> clientUsers = userQueryPort.findByIds(command.getClientUserId());
         List<User> devUsers = userQueryPort.findByIds(command.getDevUserId());
 
-        List<Long> clientCompanyIds = clientUsers.stream().map(User::getCompanyId).toList();
-        List<Long> devCompanyIds = devUsers.stream().map(User::getCompanyId).toList();
-
         List<Assignment> assignments = Assignment.createProjectUser(project,
             command.getDevManagerId(), command.getClientManagerId(), command.getDevUserId(),
-            command.getClientUserId(), devCompanyIds, clientCompanyIds);
+            command.getClientUserId(), devUsers, clientUsers);
         saveProjectUserPort.saveAll(assignments);
 
         // 알림을 위한 assignments id 리스트

--- a/module-core/src/main/java/com/back2basics/project/service/UpdateProjectService.java
+++ b/module-core/src/main/java/com/back2basics/project/service/UpdateProjectService.java
@@ -165,9 +165,6 @@ public class UpdateProjectService implements UpdateProjectUseCase {
         List<User> clientUserList = userQueryPort.findByIds(newClientUsers);
         List<User> devUserList = userQueryPort.findByIds(newDevUsers);
 
-        List<Long> clientCompanyIds = clientUserList.stream().map(User::getCompanyId).toList();
-        List<Long> devCompanyIds = devUserList.stream().map(User::getCompanyId).toList();
-
         // 생성
         List<Assignment> newAssignments = Assignment.createProjectUser(
             project,
@@ -175,8 +172,8 @@ public class UpdateProjectService implements UpdateProjectUseCase {
             clientManagers,
             newDevUsers,
             newClientUsers,
-            devCompanyIds,
-            clientCompanyIds
+            devUserList,
+            clientUserList
         );
 
         saveProjectUserPort.saveAll(newAssignments);


### PR DESCRIPTION
## 📌 개요
프로젝트 생성 시, 프로젝트 멤버(userId ↔ user 정보 매핑)가 잘못 되어  
회사 ID가 엉뚱하게 할당되는 문제를 수정했습니다.

## 🔨 작업 유형 (해당하는 항목에 X 표시)
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug fix)
- [ ] 문서 수정 (Docs)
- [ ] 빌드 업무, 패키지 매니저 설정 (Chore)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 추가 (Test)
- [ ] 스타일 수정 (Style)
- [ ] 기타 (Other)

## ✅ 작업 내용 상세
- `userQueryPort.findByIds(...)`의 반환 순서가 `userId` 리스트와 달라  
  `userId` ↔ `User`가 일치하지 않는 문제 발생
- 이를 해결하기 위해 `Map<Long, User>`로 변환 후, `userId` 순서에 맞게 재정렬
- `Assignment.createProjectUser(...)`에서 순서 기반 매핑 보장
- 잘못된 companyId가 매핑되는 이슈 해결

## 🔍 관련 이슈
<!-- 예: Close #12 -->
- Close #
- See also #

## 🧪 테스트 결과
<!-- 테스트 방법 및 결과 요약 -->
<!-- - Postman으로 회원가입 API 정상 동작 확인 -->

## 👀 리뷰어에게 요청사항
<!-- 코드 리뷰 시 중점적으로 봐줬으면 하는 부분 -->
<!-- - 이메일 형식 검증 로직에 문제 없는지 확인 부탁드립니다. -->

## 📎 기타 참고 사항
<!-- 추가적인 설명이나 참고 자료 (디자인 링크, API 문서 등) -->
<!-- - [API 문서](링크) -->
